### PR TITLE
Fixed looping in ward mode

### DIFF
--- a/RoleUtility.lua
+++ b/RoleUtility.lua
@@ -123,7 +123,19 @@ X["hero_roles"] = {
 		['support'] = 0,
 		['pusher'] = 0
 	},
-
+  
+  ["npc_dota_hero_dark_willow"] = {
+		['carry'] = 0,
+		['disabler'] = 1,
+		['durable'] = 0,
+		['escape'] = 1,
+		['initiator'] = 1,
+		['jungler'] = 0,
+		['nuker'] = 1,
+		['support'] = 1,
+		['pusher'] = 0
+	},
+  
 	["npc_dota_hero_doom_bringer"] = {
 		['carry'] = 1,
 		['disabler'] = 2,
@@ -365,7 +377,7 @@ X["hero_roles"] = {
 	},
 
 	["npc_dota_hero_sven"] = {
-		['carry'] = 2,
+		['carry'] = 3,
 		['disabler'] = 2,
 		['durable'] = 2,
 		['escape'] = 0,
@@ -581,7 +593,7 @@ X["hero_roles"] = {
 	},
 
 	["npc_dota_hero_faceless_void"] = {
-		['carry'] = 2,
+		['carry'] = 3,
 		['disabler'] = 2,
 		['durable'] = 1,
 		['escape'] = 1,
@@ -637,7 +649,7 @@ X["hero_roles"] = {
 		['jungler'] = 0,
 		['nuker'] = 2,
 		['support'] = 0,
-		['pusher'] = 0
+		['pusher'] = 2
 	},
 
 	["npc_dota_hero_medusa"] = {
@@ -797,7 +809,7 @@ X["hero_roles"] = {
 	},
 
 	["npc_dota_hero_sniper"] = {
-		['carry'] = 2,
+		['carry'] = 3,
 		['disabler'] = 0,
 		['durable'] = 0,
 		['escape'] = 0,
@@ -1147,7 +1159,7 @@ X["hero_roles"] = {
 	["npc_dota_hero_necrolyte"] = {
 		['carry'] = 1,
 		['disabler'] = 1,
-		['durable'] = 1,
+		['durable'] = 2,
 		['escape'] = 0,
 		['initiator'] = 0,
 		['jungler'] = 0,
@@ -1426,7 +1438,7 @@ X["bottle"] = {
 	["npc_dota_hero_obsidian_destroyer"] = 1;
 	["npc_dota_hero_death_prophet"] = 1;
 	["npc_dota_hero_tiny"] = 1;
-	["npc_dota_hero_dragon_knight"] = 1;
+	--["npc_dota_hero_dragon_knight"] = 1; -- it was viable when bottle crew worked, now dk has to go for soul ring if he wants mana
 	["npc_dota_hero_pugna"] = 1;
 	["npc_dota_hero_naga_siren"] = 1;
 }
@@ -1523,7 +1535,14 @@ function X.BetterBuyPhaseBoots(hero)
 end	
 
 function X.GetRoleLevel(hero, role)
-	return X["hero_roles"][hero][role];
+  if hero ~= nil and role ~= nil and X["hero_roles"][hero] ~= nil and X["hero_roles"][hero][role] ~= nil then
+    return X["hero_roles"][hero][role];
+  end
+  if hero ~= nil then
+    print("hero has no role: " .. hero);
+  end
+
+  return 0;
 end
 
 function X.IsRemovedFromSupportPoll(hero)
@@ -1558,7 +1577,6 @@ X['off'] = {
 	'npc_dota_hero_spirit_breaker',
 	'npc_dota_hero_tidehunter',
 	'npc_dota_hero_tusk',
-	'npc_dota_hero_venomancer',
 	'npc_dota_hero_windrunner'
 }
 
@@ -1567,6 +1585,7 @@ X['mid'] = {
 	'npc_dota_hero_arc_warden',
 	'npc_dota_hero_bloodseeker',
 	'npc_dota_hero_broodmother',
+	'npc_dota_hero_bristleback',
 	'npc_dota_hero_clinkz',
 	'npc_dota_hero_death_prophet',
 	'npc_dota_hero_dragon_knight',
@@ -1587,6 +1606,8 @@ X['mid'] = {
 	'npc_dota_hero_puck',
 	'npc_dota_hero_pugna',
 	'npc_dota_hero_queenofpain',
+	'npc_dota_hero_shredder',
+	'npc_dota_hero_skywrath_mage',
 	'npc_dota_hero_sniper',
 	'npc_dota_hero_storm_spirit',
 	'npc_dota_hero_templar_assassin',
@@ -1619,7 +1640,8 @@ X['safe'] = {
 	'npc_dota_hero_terrorblade',
 	'npc_dota_hero_troll_warlord',
 	'npc_dota_hero_ursa',
-	'npc_dota_hero_weaver'
+	'npc_dota_hero_weaver',
+	'npc_dota_hero_sniper'
 }
 
 X['supp'] = {
@@ -1666,12 +1688,14 @@ X['supp'] = {
 function X.CanBeOfflanerOld(hero)
 	if X["hero_roles"][hero] == nil then return false end;
 	return hero == "npc_dota_hero_bounty_hunter" or hero == "npc_dota_hero_nyx_assassin" or hero == "npc_dota_hero_magnataur" or hero == "npc_dota_hero_sand_king"
-           or hero == "npc_dota_hero_shredder" or hero == "npc_dota_hero_tusk" or hero == "npc_dota_hero_dark_seer" or hero == "npc_dota_hero_techies" or hero == "npc_dota_hero_batrider"
+           or hero == "npc_dota_hero_shredder" or hero == "npc_dota_hero_tusk" or hero == "npc_dota_hero_dark_seer" or hero == "npc_dota_hero_techies" or hero == "npc_dota_hero_batrider" 
+            or hero == "npc_dota_hero_furion" or hero == "npc_dota_hero_night_stalker" or hero == "npc_dota_hero_slardar" or hero == "npc_dota_hero_undying" or hero == "npc_dota_hero_bristleback"
 		   or (  X["hero_roles"][hero]["initiator"] > 0 and
 		         X["hero_roles"][hero]["disabler"] > 0 and
 		         X["hero_roles"][hero]["durable"] > 0 and
 		         X["hero_roles"][hero]["support"] == 0 )
 end
+
 
 function X.CanBeOfflaner(hero)
 	for i = 1, #X['off'] do
@@ -1679,19 +1703,21 @@ function X.CanBeOfflaner(hero)
 			return true;	
 		end	
 	end
+
 	return false;	
 end	
 
---MIDLANER
+
 function X.CanBeMidlanerOld(hero)
 	if X["hero_roles"][hero] == nil then return false end;
-	return hero == "npc_dota_hero_zuus" or hero == "npc_dota_hero_templar_assassin" or hero == "npc_dota_hero_ember_spirit" or hero == "npc_dota_hero_puck" 
-	       or hero == "npc_dota_hero_pugna" 
-		   or ( X["hero_roles"][hero]["carry"] > 0 and
-		      ( 
-		        X["hero_roles"][hero]["nuker"] > 0 or
-			    X["hero_roles"][hero]["pusher"] > 0 
-			   ) 
+   -- return hero == "npc_dota_hero_huskar" or hero == "npc_dota_hero_bristleback" or hero == "npc_dota_hero_necrolyte";
+	return hero == "npc_dota_hero_zuus" or 
+         hero == "npc_dota_hero_huskar" or 
+         hero == "npc_dota_hero_skywrath_mage" or 
+         hero == "npc_dota_hero_bloodseeker" or 
+         hero == "npc_dota_hero_viper" or 
+         hero == "npc_dota_hero_necrolyte" or 
+         ( X["hero_roles"][hero]["carry"] > 0 and ( X["hero_roles"][hero]["nuker"] > 0 or X["hero_roles"][hero]["pusher"] > 0 ) 
 			)
 end
 
@@ -1701,6 +1727,7 @@ function X.CanBeMidlaner(hero)
 			return true;	
 		end	
 	end
+
 	return false;	
 end	
 
@@ -1722,6 +1749,7 @@ function X.CanBeSafeLaneCarry(hero)
 			return true;	
 		end	
 	end
+
 	return false;	
 end	
 
@@ -1742,6 +1770,7 @@ function X.CanBeSupport(hero)
 			return true;	
 		end	
 	end
+
 	return false;	
 end	
 

--- a/RoleUtility.lua
+++ b/RoleUtility.lua
@@ -123,8 +123,8 @@ X["hero_roles"] = {
 		['support'] = 0,
 		['pusher'] = 0
 	},
-  
-  ["npc_dota_hero_dark_willow"] = {
+	
+	["npc_dota_hero_dark_willow"] = {
 		['carry'] = 0,
 		['disabler'] = 1,
 		['durable'] = 0,
@@ -135,7 +135,7 @@ X["hero_roles"] = {
 		['support'] = 1,
 		['pusher'] = 0
 	},
-  
+	
 	["npc_dota_hero_doom_bringer"] = {
 		['carry'] = 1,
 		['disabler'] = 2,
@@ -1535,21 +1535,21 @@ function X.BetterBuyPhaseBoots(hero)
 end	
 
 function X.GetRoleLevel(hero, role)
-  if hero ~= nil and role ~= nil and X["hero_roles"][hero] ~= nil and X["hero_roles"][hero][role] ~= nil then
-    return X["hero_roles"][hero][role];
-  end
-  if hero ~= nil then
-    print("hero has no role: " .. hero);
-  end
+	if hero ~= nil and role ~= nil and X["hero_roles"][hero] ~= nil and X["hero_roles"][hero][role] ~= nil then
+		return X["hero_roles"][hero][role];
+	end
+	if hero ~= nil then
+		print("hero has no role: " .. hero);
+	end
 
-  return 0;
+	return 0;
 end
 
 function X.IsRemovedFromSupportPoll(hero)
 	return hero == "npc_dota_hero_alchemist" or
-		   hero == "npc_dota_hero_naga_siren" or
-		   hero == "npc_dota_hero_skeleton_king" or
-		   hero == "npc_dota_hero_alchemist" 
+			 hero == "npc_dota_hero_naga_siren" or
+			 hero == "npc_dota_hero_skeleton_king" or
+			 hero == "npc_dota_hero_alchemist" 
 end
 
 X['off'] = {
@@ -1560,6 +1560,7 @@ X['off'] = {
 	'npc_dota_hero_beastmaster',
 	'npc_dota_hero_brewmaster',
 	'npc_dota_hero_bristleback',
+	'npc_dota_hero_broodmother',
 	'npc_dota_hero_centaur',
 	'npc_dota_hero_dark_seer',
 	'npc_dota_hero_doom_bringer',
@@ -1589,6 +1590,7 @@ X['mid'] = {
 	'npc_dota_hero_clinkz',
 	'npc_dota_hero_death_prophet',
 	'npc_dota_hero_dragon_knight',
+	'npc_dota_hero_drow_ranger',
 	'npc_dota_hero_ember_spirit',
 	'npc_dota_hero_huskar',
 	'npc_dota_hero_invoker',
@@ -1606,22 +1608,25 @@ X['mid'] = {
 	'npc_dota_hero_puck',
 	'npc_dota_hero_pugna',
 	'npc_dota_hero_queenofpain',
-	'npc_dota_hero_shredder',
-	'npc_dota_hero_skywrath_mage',
 	'npc_dota_hero_sniper',
 	'npc_dota_hero_storm_spirit',
 	'npc_dota_hero_templar_assassin',
 	'npc_dota_hero_tinker',
 	'npc_dota_hero_tiny',
+	'npc_dota_hero_venomancer',
 	'npc_dota_hero_viper',
-	'npc_dota_hero_zuus'
+	'npc_dota_hero_zuus',
+	'npc_dota_hero_skywrath_mage',
+	'npc_dota_hero_shredder'
 }
 
 X['safe'] = {
 	'npc_dota_hero_antimage',
+	'npc_dota_hero_broodmother',
 	'npc_dota_hero_chaos_knight',
 	'npc_dota_hero_drow_ranger',
 	'npc_dota_hero_faceless_void',
+	'npc_dota_hero_clinkz',
 	'npc_dota_hero_gyrocopter',
 	'npc_dota_hero_juggernaut',
 	'npc_dota_hero_life_stealer',
@@ -1641,7 +1646,9 @@ X['safe'] = {
 	'npc_dota_hero_troll_warlord',
 	'npc_dota_hero_ursa',
 	'npc_dota_hero_weaver',
-	'npc_dota_hero_sniper'
+	--'npc_dota_hero_huskar',
+	'npc_dota_hero_sniper',
+	'npc_dota_hero_venomancer'
 }
 
 X['supp'] = {
@@ -1676,6 +1683,7 @@ X['supp'] = {
 	'npc_dota_hero_treant',
 	'npc_dota_hero_undying',
 	'npc_dota_hero_vengefulspirit',
+	'npc_dota_hero_venomancer',
 	'npc_dota_hero_visage',
 	'npc_dota_hero_warlock',
 	'npc_dota_hero_winter_wyvern',
@@ -1688,12 +1696,12 @@ X['supp'] = {
 function X.CanBeOfflanerOld(hero)
 	if X["hero_roles"][hero] == nil then return false end;
 	return hero == "npc_dota_hero_bounty_hunter" or hero == "npc_dota_hero_nyx_assassin" or hero == "npc_dota_hero_magnataur" or hero == "npc_dota_hero_sand_king"
-           or hero == "npc_dota_hero_shredder" or hero == "npc_dota_hero_tusk" or hero == "npc_dota_hero_dark_seer" or hero == "npc_dota_hero_techies" or hero == "npc_dota_hero_batrider" 
-            or hero == "npc_dota_hero_furion" or hero == "npc_dota_hero_night_stalker" or hero == "npc_dota_hero_slardar" or hero == "npc_dota_hero_undying" or hero == "npc_dota_hero_bristleback"
-		   or (  X["hero_roles"][hero]["initiator"] > 0 and
-		         X["hero_roles"][hero]["disabler"] > 0 and
-		         X["hero_roles"][hero]["durable"] > 0 and
-		         X["hero_roles"][hero]["support"] == 0 )
+					 or hero == "npc_dota_hero_shredder" or hero == "npc_dota_hero_tusk" or hero == "npc_dota_hero_dark_seer" or hero == "npc_dota_hero_techies" or hero == "npc_dota_hero_batrider" 
+						or hero == "npc_dota_hero_furion" or hero == "npc_dota_hero_night_stalker" or hero == "npc_dota_hero_slardar" or hero == "npc_dota_hero_undying" or hero == "npc_dota_hero_bristleback"
+			 or (	X["hero_roles"][hero]["initiator"] > 0 and
+						 X["hero_roles"][hero]["disabler"] > 0 and
+						 X["hero_roles"][hero]["durable"] > 0 and
+						 X["hero_roles"][hero]["support"] == 0 )
 end
 
 
@@ -1703,21 +1711,20 @@ function X.CanBeOfflaner(hero)
 			return true;	
 		end	
 	end
-
 	return false;	
 end	
 
 
 function X.CanBeMidlanerOld(hero)
 	if X["hero_roles"][hero] == nil then return false end;
-   -- return hero == "npc_dota_hero_huskar" or hero == "npc_dota_hero_bristleback" or hero == "npc_dota_hero_necrolyte";
+	 -- return hero == "npc_dota_hero_huskar" or hero == "npc_dota_hero_bristleback" or hero == "npc_dota_hero_necrolyte";
 	return hero == "npc_dota_hero_zuus" or 
-         hero == "npc_dota_hero_huskar" or 
-         hero == "npc_dota_hero_skywrath_mage" or 
-         hero == "npc_dota_hero_bloodseeker" or 
-         hero == "npc_dota_hero_viper" or 
-         hero == "npc_dota_hero_necrolyte" or 
-         ( X["hero_roles"][hero]["carry"] > 0 and ( X["hero_roles"][hero]["nuker"] > 0 or X["hero_roles"][hero]["pusher"] > 0 ) 
+				 hero == "npc_dota_hero_huskar" or 
+				 hero == "npc_dota_hero_skywrath_mage" or 
+				 hero == "npc_dota_hero_bloodseeker" or 
+				 hero == "npc_dota_hero_viper" or 
+				 hero == "npc_dota_hero_necrolyte" or 
+				 ( X["hero_roles"][hero]["carry"] > 0 and ( X["hero_roles"][hero]["nuker"] > 0 or X["hero_roles"][hero]["pusher"] > 0 ) 
 			)
 end
 
@@ -1727,7 +1734,6 @@ function X.CanBeMidlaner(hero)
 			return true;	
 		end	
 	end
-
 	return false;	
 end	
 
@@ -1735,7 +1741,7 @@ end
 function X.CanBeSafeLaneCarryOld(hero)
 	if X["hero_roles"][hero] == nil or hero == "npc_dota_hero_obsidian_destroyer" or hero == "npc_dota_hero_storm_spirit" then return false end;
 	return X["hero_roles"][hero]["carry"] > 1 and
-		   ( 
+			 ( 
 			 ( X["hero_roles"][hero]["nuker"] < 3 and X["hero_roles"][hero]["pusher"] < 3 ) or
 			 ( X["hero_roles"][hero]["escape"] > 0 and X["hero_roles"][hero]["nuker"] < 2 ) or
 			 X["hero_roles"][hero]["nuker"] < 2 or	
@@ -1749,7 +1755,6 @@ function X.CanBeSafeLaneCarry(hero)
 			return true;	
 		end	
 	end
-
 	return false;	
 end	
 
@@ -1757,11 +1762,11 @@ end
 function X.CanBeSupportOld(hero)
 	if X["hero_roles"][hero] == nil then return false end;
 	return not X.IsRemovedFromSupportPoll(hero) and X["hero_roles"][hero]["support"] > 0 and
-		  ( 
+			( 
 			X["hero_roles"][hero]["carry"] < 2 or 
 			X["hero_roles"][hero]["nuker"] > 0 or 
-		    X["hero_roles"][hero]["disabler"] > 0 
-		   )
+				X["hero_roles"][hero]["disabler"] > 0 
+			 )
 end
 
 function X.CanBeSupport(hero)
@@ -1770,7 +1775,6 @@ function X.CanBeSupport(hero)
 			return true;	
 		end	
 	end
-
 	return false;	
 end	
 
@@ -1828,7 +1832,7 @@ function X.UpdateInvisEnemyStatus(bot)
 					local GCSlot = enemies[i]:FindItemSlot("item_glimmer_cape");
 					local ISSlot = enemies[i]:FindItemSlot("item_invis_sword");
 					local SESlot = enemies[i]:FindItemSlot("item_silver_edge");
-					if  SASlot >= 0 or GCSlot >= 0 or ISSlot >= 0 or SESlot >= 0 
+					if	SASlot >= 0 or GCSlot >= 0 or ISSlot >= 0 or SESlot >= 0 
 					then
 						X['invisEnemyExist'] = true;
 						break;
@@ -1867,7 +1871,7 @@ function X.UpdateSupportStatus(bot)
 	end
 	for i = 1, #TeamMember do
 		local ally = GetTeamMember(i);
-		if ally ~= nil and ally:IsHero() and ally.theRole == "support"  then
+		if ally ~= nil and ally:IsHero() and ally.theRole == "support"	then
 			X['supportExist'] = true;
 		end
 	end

--- a/ability_item_usage_bristleback.lua
+++ b/ability_item_usage_bristleback.lua
@@ -73,7 +73,8 @@ function ConsiderQ()
 	then
 		for _,npcEnemy in pairs( tableNearbyEnemyHeroes )
 		do
-			if ( npcBot:WasRecentlyDamagedByHero( npcEnemy, 2.0 ) and mutil.CanCastOnNonMagicImmune(npcEnemy) ) 
+			-- it is counterproductive to cast this to a target when the whole enemy team is chasing us, so cast only if we have scepter
+			if ( npcBot:WasRecentlyDamagedByHero( npcEnemy, 2.0 ) and mutil.CanCastOnNonMagicImmune(npcEnemy) and npcBot:HasScepter()) 
 			then
 				return BOT_ACTION_DESIRE_HIGH, npcEnemy;
 			end
@@ -123,16 +124,14 @@ function ConsiderW()
 	local nCastPoint = abilityW:GetCastPoint( );
 	local nManaCost  = abilityW:GetManaCost( );
 
-	-- If we're seriously retreating, see if we can land a stun on someone who's damaged us recently
+	-- If we're seriously retreating, see what we can do
 	if mutil.IsRetreating(npcBot)
 	then
 		local tableNearbyEnemyHeroes = npcBot:GetNearbyHeroes( nRadius, true, BOT_MODE_NONE );
 		for _,npcEnemy in pairs( tableNearbyEnemyHeroes )
 		do
-			if ( npcBot:WasRecentlyDamagedByHero( npcEnemy, 1.0 ) ) 
-			then
-				return BOT_ACTION_DESIRE_MODERATE;
-			end
+			-- just give them pain, we wont lose anything with this
+			return BOT_ACTION_DESIRE_ABSOLUTE;
 		end
 	end
 	
@@ -142,7 +141,7 @@ function ConsiderW()
 		local npcTarget = npcBot:GetAttackTarget();
 		if ( mutil.IsRoshan(npcTarget) and mutil.CanCastOnMagicImmune(npcTarget) and mutil.IsInRange(npcBot, npcTarget, nRadius)  )
 		then
-			return BOT_ACTION_DESIRE_MODERATE;
+			return BOT_ACTION_DESIRE_VERYHIGH;
 		end
 	end
 	
@@ -150,15 +149,16 @@ function ConsiderW()
 	if mutil.IsPushing(npcBot) or mutil.IsDefending(npcBot)
 	then
 		local tableNearbyEnemyCreeps = npcBot:GetNearbyLaneCreeps( nRadius, true );
-		if ( tableNearbyEnemyCreeps ~= nil and #tableNearbyEnemyCreeps >= 4 and mutil.AllowedToSpam(npcBot, nManaCost) ) then
-			return BOT_ACTION_DESIRE_MODERATE;
+		if ( tableNearbyEnemyCreeps ~= nil and #tableNearbyEnemyCreeps >= 2 and mutil.AllowedToSpam(npcBot, nManaCost) ) then
+			return BOT_ACTION_DESIRE_VERYHIGH;
 		end
 	end
 	
 	if mutil.IsInTeamFight(npcBot, 1200)
 	then
-		if tableNearbyEnemyHeroes ~= nil and #tableNearbyEnemyHeroes >= 2 then
-			return BOT_ACTION_DESIRE_LOW;
+		local tableNearbyEnemyHeroes = npcBot:GetNearbyHeroes( nRadius, true, BOT_MODE_NONE );
+		if tableNearbyEnemyHeroes ~= nil and #tableNearbyEnemyHeroes >= 1 then
+			return BOT_ACTION_DESIRE_VERYHIGH;
 		end
 	end
 	
@@ -166,9 +166,9 @@ function ConsiderW()
 	if mutil.IsGoingOnSomeone(npcBot)
 	then
 		local npcTarget = npcBot:GetTarget();
-		if mutil.IsValidTarget(npcTarget) and mutil.CanCastOnMagicImmune(npcTarget) and mutil.IsInRange(npcTarget, npcBot, nRadius-100)
+		if mutil.IsValidTarget(npcTarget) and mutil.CanCastOnMagicImmune(npcTarget) and mutil.IsInRange(npcTarget, npcBot, nRadius-30)
 		then
-			return BOT_ACTION_DESIRE_MODERATE;
+			return BOT_ACTION_DESIRE_VERYHIGH;
 		end
 	end
 

--- a/ability_item_usage_generic.lua
+++ b/ability_item_usage_generic.lua
@@ -940,20 +940,20 @@ function UnImplementedItemUsage()
 		end
 	end
 	
-	-- local pb=IsItemAvailable("item_phase_boots");
-	-- if pb~=nil and pb:IsFullyCastable() 
-	-- then
-	-- 	if ( mode == BOT_MODE_ATTACK or
-	-- 		 mode == BOT_MODE_RETREAT or
-	-- 		 mode == BOT_MODE_ROAM or
-	-- 		 mode == BOT_MODE_TEAM_ROAM or
-	-- 		 mode == BOT_MODE_GANK or
-	-- 		 mode == BOT_MODE_DEFEND_ALLY )
-	-- 	then
-	-- 		bot:Action_UseAbility(pb);
-	-- 		return;
-	-- 	end	
-	-- end
+	local pb=IsItemAvailable("item_phase_boots");
+	if pb~=nil and pb:IsFullyCastable() 
+	then
+		if ( mode == BOT_MODE_ATTACK or
+			 mode == BOT_MODE_RETREAT or
+			 mode == BOT_MODE_ROAM or
+			 mode == BOT_MODE_TEAM_ROAM or
+			 mode == BOT_MODE_GANK or
+			 mode == BOT_MODE_DEFEND_ALLY )
+		then
+			bot:Action_UseAbility(pb);
+			return;
+		end	
+	end
 	
 	local bt=IsItemAvailable("item_bloodthorn");
 	if bt~=nil and bt:IsFullyCastable() 

--- a/ability_item_usage_huskar.lua
+++ b/ability_item_usage_huskar.lua
@@ -6,6 +6,7 @@ end
 local ability_item_usage_generic = dofile( GetScriptDirectory().."/ability_item_usage_generic" )
 local utils = require(GetScriptDirectory() ..  "/util")
 local mutil = require(GetScriptDirectory() ..  "/MyUtility")
+local role = require(GetScriptDirectory() .. "/RoleUtility");
 
 function AbilityLevelUpThink()  
 	ability_item_usage_generic.AbilityLevelUpThink(); 
@@ -104,9 +105,10 @@ function ConsiderInnerVitality()
 
 end
 
+local rangeExtension = 250;
 
 function ConsiderBurningSpear()
-
+  
 	-- Make sure it's castable
 	if ( not abilityBS:IsFullyCastable() ) then 
 		return BOT_ACTION_DESIRE_NONE, 0;
@@ -118,14 +120,58 @@ function ConsiderBurningSpear()
 	local nRadius = 0;
 	local nAttackRange = npcBot:GetAttackRange();
 	
+	local mode = npcBot:GetActiveMode();	
+	
 	-- If we're going after someone
-	if mutil.IsGoingOnSomeone(npcBot)
+	if mutil.IsGoingOnSomeone(npcBot) or mode == BOT_MODE_LANING or mode == BOT_MODE_DEFEND_TOWER_MID or  mode == BOT_MODE_PUSH_TOWER_MID
 	then
 		local npcTarget = npcBot:GetTarget();
-		if mutil.IsValidTarget(npcTarget) and mutil.CanCastOnNonMagicImmune(npcTarget) and mutil.IsInRange(npcTarget, npcBot, nAttackRange+200)
-		then
-			return BOT_ACTION_DESIRE_MODERATE, npcTarget;
+		
+		if npcTarget == nil then
+			local tableNearbyEnemyHeroes = npcBot:GetNearbyHeroes( 1600, true, BOT_MODE_NONE );
+      
+      for _,npcEnemy in pairs( tableNearbyEnemyHeroes )
+        do
+          if ( npcBot:WasRecentlyDamagedByHero( npcEnemy, 2.0 ) ) 
+          then
+            npcTarget = npcEnemy;
+            break;
+          end
+        end
+    
+      if npcTarget == nil then
+        npcTarget = tableNearbyEnemyHeroes[1];
+      end
 		end
+    
+    if mode == BOT_MODE_LANING and DotaTime() > 13 and DotaTime() < 100 and npcTarget ~= nil and not role.IsMelee(npcTarget:GetAttackRange()) then
+        return BOT_ACTION_DESIRE_NONE, 0;
+    end
+		
+    if mutil.IsValidTarget(npcTarget) and mutil.CanCastOnNonMagicImmune(npcTarget) then
+      
+      -- sacrefise in teamfight - we have no escape mechanism anyway, but we are good at killing
+      if mutil.IsInTeamFight(npcBot, 1200) and npcBot:GetHealth() < npcBot:GetMaxHealth() * 0.34 and mutil.IsInRange(npcTarget, npcBot, nAttackRange) then
+          return BOT_ACTION_DESIRE_ABSOLUTE, npcTarget;
+      end
+      
+      -- someone wants to kill us alone
+      if npcBot:GetHealth() < npcBot:GetMaxHealth() * 0.30 and mutil.IsInRange(npcTarget, npcBot, nAttackRange * 0.66) and npcTarget:GetHealth() < npcTarget:GetMaxHealth() * 0.7 then
+          return BOT_ACTION_DESIRE_ABSOLUTE, npcTarget;
+      end
+      
+      -- be more agressive on meele heroes during laning phase or we can go on ranged heroes from leve 5
+      if mutil.IsInRange(npcTarget, npcBot, nAttackRange+rangeExtension+300) and mode == BOT_MODE_LANING 
+        and utils.GetDistFromEnemyMidTower() > 1100+rangeExtension and (role.IsMelee(npcTarget:GetAttackRange()) or npcBot:GetLevel() > 4) then
+        return BOT_ACTION_DESIRE_HIGH, npcTarget;
+      end
+      
+      
+      if mutil.IsInRange(npcTarget, npcBot, nAttackRange+rangeExtension) and (mode ~= BOT_MODE_LANING or utils.GetDistFromEnemyMidTower() > 1050+rangeExtension)  then
+        return BOT_ACTION_DESIRE_MODERATE, npcTarget;
+      end
+      
+    end
 	end
 	
 	return BOT_ACTION_DESIRE_NONE, 0;
@@ -144,7 +190,7 @@ function ConsiderLifeBreak()
 	if mutil.IsGoingOnSomeone(npcBot)
 	then
 		local npcTarget = npcBot:GetTarget();
-		if mutil.IsValidTarget(npcTarget) and mutil.CanCastOnNonMagicImmune(npcTarget) and mutil.IsInRange(npcTarget, npcBot, nCastRange+200)
+		if mutil.IsValidTarget(npcTarget) and mutil.CanCastOnNonMagicImmune(npcTarget) and mutil.IsInRange(npcTarget, npcBot, nCastRange+rangeExtension)
 		then
 			return BOT_ACTION_DESIRE_VERYHIGH, npcTarget;
 		end

--- a/builds/item_build_bristleback.lua
+++ b/builds/item_build_bristleback.lua
@@ -8,14 +8,16 @@ X["items"] = {
 	"item_magic_wand",
 	"item_power_treads_str",
 	"item_vanguard",
-	"item_blade_mail",
+	"item_platemail",
 	"item_pipe",
 	"item_crimson_guard",
-	"item_shivas_guard",
-	"item_octarine_core"
+	"item_lotus_orb",
+	"item_octarine_core",
+	"item_assault"
 };
 
 X["builds"] = {
+	{2,3,2,3,2,1,2,3,4,3,4,1,1,1,4},
 	{2,3,2,3,2,4,2,3,3,1,4,1,1,1,4},
 	{2,3,2,3,2,4,2,1,3,3,4,1,1,1,4}
 }
@@ -23,7 +25,7 @@ X["builds"] = {
 X["skills"] = IBUtil.GetBuildPattern(
 	  "normal", 
 	  IBUtil.GetRandomBuild(X['builds']), skills, 
-	  {1,4,6,7}, talents
+	  {1,3,6,7}, talents
 );
 
 return X

--- a/builds/item_build_huskar.lua
+++ b/builds/item_build_huskar.lua
@@ -18,14 +18,14 @@ X["items"] = {
 };			
 
 X["builds"] = {
-	{2,3,2,1,2,4,2,3,3,3,4,1,1,1,4},
-	{2,3,3,1,3,4,3,1,1,1,4,2,2,2,4}
+  {2,3,2,3,2,4,2,3,3,1,4,1,1,1,4},
+  {2,3,3,2,3,4,3,2,2,1,4,1,1,1,4}
 }
 
 X["skills"] = IBUtil.GetBuildPattern(
 	  "normal", 
 	  IBUtil.GetRandomBuild(X['builds']), skills, 
-	  {1,4,6,8}, talents
+	  {1,4,5,7}, talents
 );
 
 return X

--- a/counters.lua
+++ b/counters.lua
@@ -1,0 +1,449 @@
+local role = require(GetScriptDirectory() .. "/RoleUtility");
+local heroStrength = {}; -- 1-3
+local counters = {};
+randomValues = {}
+
+counters['npc_dota_hero_abaddon'] = { 'npc_dota_hero_slark', 'npc_dota_hero_undying' , 'npc_dota_hero_viper', 'npc_dota_hero_abyssal_underlord'}
+heroStrength['npc_dota_hero_abaddon'] = 5
+
+counters['npc_dota_hero_alchemist'] = { 'npc_dota_hero_bloodseeker', 'npc_dota_hero_huskar', 'npc_dota_hero_slark', 'npc_dota_hero_ursa', 'npc_dota_hero_dazzle', 'npc_dota_hero_ancient_apparition'}
+heroStrength['npc_dota_hero_alchemist'] = 1
+
+counters['npc_dota_hero_ancient_apparition'] = { 'npc_dota_hero_antimage', 'npc_dota_hero_brewmaster', 'npc_dota_hero_chaos_knight'}
+heroStrength['npc_dota_hero_ancient_apparition'] = 2
+
+counters['npc_dota_hero_arc_warden'] = {'npc_dota_hero_broodmother', 'npc_dota_hero_phantom_lancer',	'npc_dota_hero_lycan', 'npc_dota_hero_slark', 'npc_dota_hero_chaos_knight', 'npc_dota_hero_antimage', 'npc_dota_hero_abaddon', 'npc_dota_hero_centaur', 'npc_dota_hero_brewmaster'}
+heroStrength['npc_dota_hero_arc_warden'] = 3
+
+counters['npc_dota_hero_antimage'] = {'npc_dota_hero_meepo', 'npc_dota_hero_phantom_assassin', 'npc_dota_hero_axe', 'npc_dota_hero_drow_ranger', 'npc_dota_hero_bloodseeker', 'npc_dota_hero_luna', 'npc_dota_hero_spirit_breaker', 'npc_dota_hero_terrorblade'}
+heroStrength['npc_dota_hero_antimage'] = 1
+
+counters['npc_dota_hero_axe'] = {'npc_dota_hero_necrolyte', 'npc_dota_hero_zuus', 'npc_dota_hero_ursa', 'npc_dota_hero_jakiro', 'npc_dota_hero_warlock', 'npc_dota_hero_skeleton_king', 'npc_dota_hero_phoenix','npc_dota_hero_witch_doctor'}
+heroStrength['npc_dota_hero_axe'] = 5
+
+counters['npc_dota_hero_bane'] = {'npc_dota_hero_naga_siren', 'npc_dota_hero_leshrac', 'npc_dota_hero_meepo', 'npc_dota_hero_chaos_knight', 'npc_dota_hero_winter_wyvern', 'npc_dota_hero_omniknight', 'npc_dota_hero_abyssal_underlord', 'npc_dota_hero_tidehunter', 'npc_dota_hero_spirit_breaker', 'npc_dota_hero_beastmaster'}
+heroStrength['npc_dota_hero_bane'] = 2
+
+counters['npc_dota_hero_batrider'] = {'npc_dota_hero_enigma', 'npc_dota_hero_leshrac', 'npc_dota_hero_abaddon', 'npc_dota_hero_slark', 'npc_dota_hero_omniknight', 'npc_dota_hero_clinkz', 'npc_dota_hero_warlock', 'npc_dota_hero_huskar',	'npc_dota_hero_vengefulspirit', 'npc_dota_hero_jakiro'}
+heroStrength['npc_dota_hero_batrider'] = 1
+
+counters['npc_dota_hero_beastmaster'] = {'npc_dota_hero_elder_titan', 'npc_dota_hero_winter_wyvern', 'npc_dota_hero_axe', 'npc_dota_hero_dark_seer', 'npc_dota_hero_abyssal_underlord', 'npc_dota_hero_terrorblade', 'npc_dota_hero_jakiro', 'npc_dota_hero_spectre', 'npc_dota_hero_warlock', 'npc_dota_hero_tidehunter', 'npc_dota_hero_necrolyte'}
+heroStrength['npc_dota_hero_beastmaster'] = 2
+
+counters['npc_dota_hero_bloodseeker'] = {'npc_dota_hero_storm_spirit','npc_dota_hero_pudge', 'npc_dota_hero_zuus','npc_dota_hero_brewmaster', 'npc_dota_hero_axe', 'npc_dota_hero_ursa'}
+heroStrength['npc_dota_hero_bloodseeker'] = 5
+
+counters['npc_dota_hero_bounty_hunter'] = {'npc_dota_hero_slardar', 'npc_dota_hero_bloodseeker', 'npc_dota_hero_meepo', 'npc_dota_hero_slark', 'npc_dota_hero_oracle', 'npc_dota_hero_huskar', 'npc_dota_hero_crystal_maiden', 'npc_dota_hero_luna'}
+heroStrength['npc_dota_hero_bounty_hunter'] = 1
+
+counters['npc_dota_hero_brewmaster'] = {'npc_dota_hero_sand_king', 'npc_dota_hero_luna', 'npc_dota_hero_skywrath_mage', 'npc_dota_hero_faceless_void', 'npc_dota_hero_magnataur', 'npc_dota_hero_leshrac'}
+heroStrength['npc_dota_hero_brewmaster'] = -5 -- during teamfights this hero becomes ineffective
+
+counters['npc_dota_hero_bristleback'] = {'npc_dota_hero_slark', 'npc_dota_hero_viper', 'npc_dota_hero_necrolyte', 'npc_dota_hero_ancient_apparition', 'npc_dota_hero_legion_commander', 'npc_dota_hero_silencer', 'npc_dota_hero_dazzle', 'npc_dota_hero_slardar'}
+heroStrength['npc_dota_hero_bristleback'] = 5
+
+counters['npc_dota_hero_broodmother'] = {'npc_dota_hero_earthshaker', 'npc_dota_hero_meepo', 'npc_dota_hero_kunkka', 'npc_dota_hero_monkey_king', 'npc_dota_hero_legion_commander','npc_dota_hero_sven', 'npc_dota_hero_axe', 'npc_dota_hero_magnataur', 'npc_dota_hero_leshrac', 'npc_dota_hero_crystal_maiden', 'npc_dota_hero_tidehunter', 'npc_dota_hero_sand_king', 'npc_dota_hero_necrolyte', 'npc_dota_hero_bristleback'}
+heroStrength['npc_dota_hero_broodmother'] = 3
+
+counters['npc_dota_hero_huskar'] = {'npc_dota_hero_axe', 'npc_dota_hero_chaos_knight', 'npc_dota_hero_viper', 'npc_dota_hero_phantom_lancer', 'npc_dota_hero_ancient_apparition', 'npc_dota_hero_riki', 'npc_dota_hero_clinkz', 'npc_dota_hero_broodmother', 'npc_dota_hero_bristleback', 'npc_dota_hero_ursa', 'npc_dota_hero_necrolyte', 'npc_dota_hero_witch_doctor'}
+heroStrength['npc_dota_hero_huskar'] = 3
+
+counters['npc_dota_hero_necrolyte'] = {'npc_dota_hero_pugna', 'npc_dota_hero_drow_ranger', 'npc_dota_hero_sniper', 'npc_dota_hero_ancient_apparition', 'npc_dota_hero_skywrath_mage'}
+heroStrength['npc_dota_hero_necrolyte'] = 7
+
+counters['npc_dota_hero_jakiro'] = {'npc_dota_hero_life_stealer', 'npc_dota_hero_clinkz', 'npc_dota_hero_sniper', 'npc_dota_hero_alchemist', 'npc_dota_hero_antimage', 'npc_dota_hero_elder_titan', 'npc_dota_hero_silencer', 'npc_dota_hero_bloodseeker'}
+heroStrength['npc_dota_hero_jakiro'] = 7
+
+counters['npc_dota_hero_warlock'] = {'npc_dota_hero_drow_ranger', 'npc_dota_hero_broodmother', 'npc_dota_hero_huskar', 'npc_dota_hero_bristleback', 'npc_dota_hero_slark', 'npc_dota_hero_lich', 'npc_dota_hero_ursa', 'npc_dota_hero_riki'}
+heroStrength['npc_dota_hero_warlock'] = 4
+
+counters['npc_dota_hero_lich'] = {'npc_dota_hero_sand_king', 'npc_dota_hero_slark', 'npc_dota_hero_antimage'}
+heroStrength['npc_dota_hero_lich'] = 5
+
+counters['npc_dota_hero_chaos_knight'] = {'npc_dota_hero_sven', 'npc_dota_hero_enigma', 'npc_dota_hero_phantom_lancer', 'npc_dota_hero_shredder',	'npc_dota_hero_warlock', 'npc_dota_hero_undying','npc_dota_hero_earthshaker', 'npc_dota_hero_brewmaster','npc_dota_hero_witch_doctor', 'npc_dota_hero_abyssal_underlord', 'npc_dota_hero_phoenix', 'npc_dota_hero_tidehunter'}
+heroStrength['npc_dota_hero_chaos_knight'] = 3
+
+counters['npc_dota_hero_slardar'] = {'npc_dota_hero_terrorblade', 'npc_dota_hero_luna', 'npc_dota_hero_tidehunter', 'npc_dota_hero_omniknight', 'npc_dota_hero_jakiro'}
+heroStrength['npc_dota_hero_slardar'] = 4
+
+counters['npc_dota_hero_sven'] = {'npc_dota_hero_spectre', 'npc_dota_hero_phoenix', 'npc_dota_hero_medusa', 'npc_dota_hero_undying', 'npc_dota_hero_razor', 'npc_dota_hero_sniper', 'npc_dota_hero_abaddon', 'npc_dota_hero_treant','npc_dota_hero_witch_doctor'}
+heroStrength['npc_dota_hero_sven'] = 2
+
+counters['npc_dota_hero_venomancer'] = {'npc_dota_hero_huskar', 'npc_dota_hero_broodmother', 'npc_dota_hero_arc_warden', 'npc_dota_hero_antimage', 'npc_dota_hero_pudge', 'npc_dota_hero_lycan', 'npc_dota_hero_warlock', 'npc_dota_hero_ancient_apparition', 'npc_dota_hero_abaddon', 'npc_dota_hero_juggernaut', 'npc_dota_hero_slark'}
+heroStrength['npc_dota_hero_venomancer'] = 3
+
+counters['npc_dota_hero_sniper'] = {'npc_dota_hero_storm_spirit','npc_dota_hero_pudge','npc_dota_hero_morphling', 'npc_dota_hero_spectre', 'npc_dota_hero_centaur', 'npc_dota_hero_phantom_assassin', 'npc_dota_hero_spirit_breaker'}
+heroStrength['npc_dota_hero_sniper'] = 5
+
+counters['npc_dota_hero_drow_ranger'] = {'npc_dota_hero_spectre', 'npc_dota_hero_centaur', 'npc_dota_hero_phantom_assassin', 'npc_dota_hero_spirit_breaker', 'npc_dota_hero_slark', 'npc_dota_hero_pudge', 'npc_dota_hero_chaos_knight', 'npc_dota_hero_axe', 'npc_dota_hero_riki', 'npc_dota_hero_bounty_hunter', 'npc_dota_hero_broodmother'}
+heroStrength['npc_dota_hero_drow_ranger'] = 2
+
+counters['npc_dota_hero_riki'] = {'npc_dota_hero_slardar', 'npc_dota_hero_bloodseeker', 'npc_dota_hero_zuus', 'npc_dota_hero_bounty_hunter'}
+heroStrength['npc_dota_hero_riki'] = 2
+
+counters['npc_dota_hero_nevermore'] = {'npc_dota_hero_zuus', 'npc_dota_hero_arc_warden', 'npc_dota_hero_terrorblade', 'npc_dota_hero_pudge', 'npc_dota_hero_ursa', 'npc_dota_hero_axe', 'npc_dota_hero_skywrath_mage', 'npc_dota_hero_chaos_knight', 'npc_dota_hero_spirit_breaker'}
+heroStrength['npc_dota_hero_nevermore'] = 2
+
+counters['npc_dota_hero_zuus'] = {'npc_dota_hero_broodmother', 'npc_dota_hero_antimage', 'npc_dota_hero_huskar', 'npc_dota_hero_lycan'}
+heroStrength['npc_dota_hero_zuus'] = 2
+
+counters['npc_dota_hero_viper'] = {'npc_dota_hero_terrorblade', 'npc_dota_hero_chaos_knight', 'npc_dota_hero_riki', 'npc_dota_hero_clinkz', 'npc_dota_hero_phantom_lancer', 'npc_dota_hero_juggernaut', 'npc_dota_hero_brewmaster','npc_dota_hero_furion','npc_dota_hero_bloodseeker','npc_dota_hero_naga_siren','npc_dota_hero_morphling','npc_dota_hero_drow_ranger','npc_dota_hero_broodmother'}
+heroStrength['npc_dota_hero_viper'] = 3
+
+counters['npc_dota_hero_phantom_lancer'] = {'npc_dota_hero_axe', 'npc_dota_hero_sven', 'npc_dota_hero_earthshaker', 'npc_dota_hero_sand_king', 'npc_dota_hero_ember_spirit', 'npc_dota_hero_shredder', 'npc_dota_hero_jakiro', 'npc_dota_hero_legion_commander', 'npc_dota_hero_centaur', 'npc_dota_hero_crystal_maiden'}
+heroStrength['npc_dota_hero_phantom_lancer'] = -10 -- hero is buggy, sometimes just stucks at the fountain
+
+counters['npc_dota_hero_centaur'] = {'npc_dota_hero_dazzle', 'npc_dota_hero_undying', 'npc_dota_hero_warlock', 'npc_dota_hero_lycan', 'npc_dota_hero_witch_doctor', 'npc_dota_hero_abyssal_underlord', 'npc_dota_hero_bristleback'}
+heroStrength['npc_dota_hero_centaur'] = 3
+
+counters['npc_dota_hero_chen'] = {'npc_dota_hero_lycan', 'npc_dota_hero_leshrac', 'npc_dota_hero_lone_druid', 'npc_dota_hero_oracle', 'npc_dota_hero_naga_siren', 'npc_dota_hero_slark', 'npc_dota_hero_phantom_lancer', 'npc_dota_hero_medusa', 'npc_dota_hero_faceless_void', 'npc_dota_hero_skywrath_mage'}
+heroStrength['npc_dota_hero_chen'] = 1
+
+counters['npc_dota_hero_clinkz'] = {'npc_dota_hero_meepo', 'npc_dota_hero_slark', 'npc_dota_hero_phantom_assassin', 'npc_dota_hero_abaddon', 'npc_dota_hero_bounty_hunter', 'npc_dota_hero_chaos_knight', 'npc_dota_hero_naga_siren', 'npc_dota_hero_zuus', 'npc_dota_hero_bloodseeker', 'npc_dota_hero_spirit_breaker', 'npc_dota_hero_legion_commander', 'npc_dota_hero_morphling', 'npc_dota_hero_spectre', 'npc_dota_hero_dragon_knight', 'npc_dota_hero_bristleback', 'npc_dota_hero_phantom_lancer'}
+heroStrength['npc_dota_hero_clinkz'] = 3
+
+counters['npc_dota_hero_rattletrap'] = {'npc_dota_hero_broodmother', 'npc_dota_hero_antimage', 'npc_dota_hero_phantom_lancer', 'npc_dota_hero_huskar', 'npc_dota_hero_visage', 'npc_dota_hero_chaos_knight', 'npc_dota_hero_phoenix', 'npc_dota_hero_ember_spirit', 'npc_dota_hero_undying',	'npc_dota_hero_juggernaut',}
+heroStrength['npc_dota_hero_rattletrap'] = 1
+
+counters['npc_dota_hero_crystal_maiden'] = {'npc_dota_hero_bristleback',	'npc_dota_hero_pudge', 	'npc_dota_hero_zuus', 'npc_dota_hero_phoenix', 'npc_dota_hero_centaur', 'npc_dota_hero_undying', 'npc_dota_hero_axe', 'npc_dota_hero_silencer','npc_dota_hero_witch_doctor'}
+heroStrength['npc_dota_hero_crystal_maiden'] = 2
+
+counters['npc_dota_hero_ember_spirit'] = { 'npc_dota_hero_huskar',	'npc_dota_hero_drow_ranger', 'npc_dota_hero_slark', 'npc_dota_hero_dazzle', 'npc_dota_hero_juggernaut', 'npc_dota_hero_viper', 'npc_dota_hero_ursa', 'npc_dota_hero_sven', 'npc_dota_hero_clinkz', 'npc_dota_hero_oracle', 'npc_dota_hero_legion_commander', 'npc_dota_hero_shadow_shaman', 'npc_dota_hero_skywrath_mage', 'npc_dota_hero_faceless_void', 'npc_dota_hero_troll_warlord'}
+heroStrength['npc_dota_hero_ember_spirit'] = 0
+
+counters['npc_dota_hero_riki'] = { 'npc_dota_hero_ogre_magi', 'npc_dota_hero_bounty_hunter', 'npc_dota_hero_bristleback', 'npc_dota_hero_abyssal_underlord', 'npc_dota_hero_slardar', 'npc_dota_hero_zuus', 'npc_dota_hero_centaur', 'npc_dota_hero_axe', 'npc_dota_hero_bloodseeker', 'npc_dota_hero_dazzle', 'npc_dota_hero_abaddon', 'npc_dota_hero_treant'}
+heroStrength['npc_dota_hero_riki'] = 3
+
+counters['npc_dota_hero_skywrath_mage'] = { 'npc_dota_hero_chaos_knight','npc_dota_hero_pugna','npc_dota_hero_templar_assassin','npc_dota_hero_lycan', 'npc_dota_hero_skeleton_king', 'npc_dota_hero_antimage', 'npc_dota_hero_bristleback', 'npc_dota_hero_tidehunter', 'npc_dota_hero_broodmother', 'npc_dota_hero_phantom_lancer'}
+heroStrength['npc_dota_hero_skywrath_mage'] = 2
+
+counters['npc_dota_hero_dark_seer'] = {'npc_dota_hero_ursa', 'npc_dota_hero_crystal_maiden', 'npc_dota_hero_enigma', 'npc_dota_hero_spirit_breaker', 'npc_dota_hero_zuus', 'npc_dota_hero_bloodseeker', 'npc_dota_hero_antimage', 'npc_dota_hero_earthshaker', 'npc_dota_hero_clinkz', 'npc_dota_hero_sniper', 'npc_dota_hero_legion_commander', 'npc_dota_hero_kunkka', 'npc_dota_hero_faceless_void'}
+heroStrength['npc_dota_hero_dark_seer'] = 1
+
+counters['npc_dota_hero_dark_willow'] = {'npc_dota_hero_phantom_lancer','npc_dota_hero_venomancer','npc_dota_hero_arc_warden','npc_dota_hero_clinkz','npc_dota_hero_axe','npc_dota_hero_broodmother',
+	'npc_dota_hero_antimage','npc_dota_hero_bloodseeker','npc_dota_hero_zuus', 'npc_dota_hero_juggernaut','npc_dota_hero_centaur','npc_dota_hero_pugna', 'npc_dota_hero_jakiro'}
+heroStrength['npc_dota_hero_dark_willow'] = 1
+
+counters['npc_dota_hero_dazzle'] = {'npc_dota_hero_luna','npc_dota_hero_ancient_apparition','npc_dota_hero_silencer','npc_dota_hero_grimstroke','npc_dota_hero_faceless_void','npc_dota_hero_magnataur','npc_dota_hero_venomancer','npc_dota_hero_viper','npc_dota_hero_obsidian_destroyer','npc_dota_hero_shadow_demon'}
+heroStrength['npc_dota_hero_dazzle'] = 3
+
+counters['npc_dota_hero_death_prophet'] = {'npc_dota_hero_medusa','npc_dota_hero_sniper', 'npc_dota_hero_luna','npc_dota_hero_mirana','npc_dota_hero_vengefulspirit','npc_dota_hero_undying','npc_dota_hero_ancient_apparition','npc_dota_hero_abyssal_underlord','npc_dota_hero_slark', 'npc_dota_hero_dazzle'}
+heroStrength['npc_dota_hero_death_prophet'] = 1
+
+counters['npc_dota_hero_disruptor'] = {'npc_dota_hero_warlock','npc_dota_hero_phantom_assassin','npc_dota_hero_oracle','npc_dota_hero_chaos_knight','npc_dota_hero_elder_titan','npc_dota_hero_huskar','npc_dota_hero_viper','npc_dota_hero_abaddon','npc_dota_hero_abyssal_underlord','npc_dota_hero_broodmother','npc_dota_hero_spirit_breaker'}
+heroStrength['npc_dota_hero_disruptor'] = 1
+
+counters['npc_dota_hero_doom_bringer'] = {'npc_dota_hero_meepo','npc_dota_hero_antimage','npc_dota_hero_huskar','npc_dota_hero_chaos_knight','npc_dota_hero_bloodseeker','npc_dota_hero_slardar','npc_dota_hero_dazzle'}
+heroStrength['npc_dota_hero_doom_bringer'] = 2
+
+counters['npc_dota_hero_earth_spirit'] = {'npc_dota_hero_death_prophet','npc_dota_hero_lycan','npc_dota_hero_leshrac','npc_dota_hero_enchantress','npc_dota_hero_life_stealer','npc_dota_hero_weaver','npc_dota_hero_bloodseeker','npc_dota_hero_clinkz','npc_dota_hero_sven','npc_dota_hero_viper','npc_dota_hero_elder_titan','npc_dota_hero_faceless_void','npc_dota_hero_huskar','npc_dota_hero_slark','npc_dota_hero_centaur','npc_dota_hero_kunkka','npc_dota_hero_juggernaut','npc_dota_hero_slardar','npc_dota_hero_ursa','npc_dota_hero_omniknight','npc_dota_hero_antimage','npc_dota_hero_necrolyte','npc_dota_hero_medusa'}
+heroStrength['npc_dota_hero_earth_spirit'] = 1
+
+counters['npc_dota_hero_earthshaker'] = {'npc_dota_hero_life_stealer','npc_dota_hero_spectre','npc_dota_hero_viper','npc_dota_hero_templar_assassin','npc_dota_hero_rattletrap', 'npc_dota_hero_sniper','npc_dota_hero_venomancer','npc_dota_hero_monkey_king','npc_dota_hero_night_stalker','npc_dota_hero_zuus','npc_dota_hero_riki',}
+heroStrength['npc_dota_hero_earthshaker'] = 2
+
+counters['npc_dota_hero_luna'] = { 'npc_dota_hero_bristleback', 'npc_dota_hero_shadow_demon', 'npc_dota_hero_dark_seer','npc_dota_hero_rattletrap','npc_dota_hero_abyssal_underlord', 'npc_dota_hero_sand_king','npc_dota_hero_spirit_breaker'}
+heroStrength['npc_dota_hero_luna'] = 2
+
+counters['npc_dota_hero_juggernaut'] = { 'npc_dota_hero_morphling', 'npc_dota_hero_antimage', 'npc_dota_hero_night_stalker', 'npc_dota_hero_axe', 'npc_dota_hero_ursa', 'npc_dota_hero_faceless_void', 'npc_dota_hero_sven', 'npc_dota_hero_dragon_knight', 'npc_dota_hero_drow_ranger', 'npc_dota_hero_sniper'}
+heroStrength['npc_dota_hero_juggernaut'] = 2
+
+counters['npc_dota_hero_tidehunter'] = { 'npc_dota_hero_huskar', 'npc_dota_hero_bloodseeker', 'npc_dota_hero_slark', 'npc_dota_hero_necrolyte', 'npc_dota_hero_undying', 'npc_dota_hero_juggernaut', 'npc_dota_hero_antimage', 	'npc_dota_hero_ursa','npc_dota_hero_abyssal_underlord'}
+heroStrength['npc_dota_hero_tidehunter'] = 3
+
+counters['npc_dota_hero_ursa'] = { 'npc_dota_hero_phantom_lancer', 'npc_dota_hero_venomancer', 'npc_dota_hero_naga_siren', 'npc_dota_hero_brewmaster', 'npc_dota_hero_sand_king', 'npc_dota_hero_lich', 'npc_dota_hero_visage', 'npc_dota_hero_slark',	'npc_dota_hero_chaos_knight'}
+heroStrength['npc_dota_hero_ursa'] = 3
+
+counters['npc_dota_hero_troll_warlord'] = {'npc_dota_hero_tinker','npc_dota_hero_batrider','npc_dota_hero_pugna','npc_dota_hero_axe','npc_dota_hero_razor','npc_dota_hero_shadow_demon','npc_dota_hero_lion','npc_dota_hero_abaddon','npc_dota_hero_brewmaster','npc_dota_hero_luna','npc_dota_hero_lich','npc_dota_hero_phoenix','npc_dota_hero_abyssal_underlord', 'npc_dota_hero_sand_king','npc_dota_hero_slark'}
+heroStrength['npc_dota_hero_troll_warlord'] = 1
+
+counters['npc_dota_hero_grimstroke'] = {'npc_dota_hero_sniper','npc_dota_hero_lycan','npc_dota_hero_clinkz','npc_dota_hero_bloodseeker','npc_dota_hero_huskar','npc_dota_hero_spectre', 'npc_dota_hero_chaos_knight','npc_dota_hero_antimage','npc_dota_hero_elder_titan'}
+heroStrength['npc_dota_hero_grimstroke'] = 1
+
+counters['npc_dota_hero_dragon_knight'] = {'npc_dota_hero_slark','npc_dota_hero_meepo','npc_dota_hero_necrolyte','npc_dota_hero_shredder','npc_dota_hero_huskar','npc_dota_hero_obsidian_destroyer','npc_dota_hero_abyssal_underlord', 'npc_dota_hero_viper','npc_dota_hero_undying','npc_dota_hero_enigma','npc_dota_hero_lich','npc_dota_hero_razor','npc_dota_hero_phoenix','npc_dota_hero_warlock','npc_dota_hero_ancient_apparition', 'npc_dota_hero_dazzle','npc_dota_hero_beastmaster', 'npc_dota_hero_tidehunter', 'npc_dota_hero_luna', 'npc_dota_hero_bloodseeker','npc_dota_hero_witch_doctor','npc_dota_hero_omniknight','npc_dota_hero_drow_ranger','npc_dota_hero_sniper'}
+heroStrength['npc_dota_hero_dragon_knight'] = 1
+
+counters['npc_dota_hero_slark'] = {'npc_dota_hero_necrolyte','npc_dota_hero_bloodseeker', 'npc_dota_hero_sand_king', 'npc_dota_hero_earthshaker','npc_dota_hero_faceless_void','npc_dota_hero_lion','npc_dota_hero_grimstroke','npc_dota_hero_omniknight','npc_dota_hero_disruptor','npc_dota_hero_ancient_apparition','npc_dota_hero_huskar','npc_dota_hero_pugna', 'npc_dota_hero_centaur','npc_dota_hero_techies'}
+heroStrength['npc_dota_hero_slark'] = -5
+
+counters['npc_dota_hero_razor'] = {'npc_dota_hero_gyrocopter','npc_dota_hero_bristleback','npc_dota_hero_morphling','npc_dota_hero_sniper','npc_dota_hero_bloodseeker','npc_dota_hero_terrorblade','npc_dota_hero_enigma', 'npc_dota_hero_witch_doctor','npc_dota_hero_chaos_knight','npc_dota_hero_antimage','npc_dota_hero_skywrath_mage','npc_dota_hero_luna'}
+heroStrength['npc_dota_hero_razor'] = 1
+
+counters['npc_dota_hero_pudge'] = {'npc_dota_hero_undying','npc_dota_hero_dazzle','npc_dota_hero_chaos_knight','npc_dota_hero_ursa', 'npc_dota_hero_skeleton_king','npc_dota_hero_slardar','npc_dota_hero_lycan','npc_dota_hero_antimage','npc_dota_hero_witch_doctor','npc_dota_hero_sven','npc_dota_hero_kunkka','npc_dota_hero_bristleback','npc_dota_hero_life_stealer','npc_dota_hero_lone_druid','npc_dota_hero_weaver','npc_dota_hero_chen','npc_dota_hero_phantom_lancer','npc_dota_hero_treant','npc_dota_hero_broodmother','npc_dota_hero_weaver'}
+heroStrength['npc_dota_hero_pudge'] = 1
+
+counters['npc_dota_hero_treant'] = {'npc_dota_hero_slark', 'npc_dota_hero_undying', 'npc_dota_hero_dazzle','npc_dota_hero_ursa','npc_dota_hero_necrolyte', 'npc_dota_hero_tidehunter','npc_dota_hero_huskar','npc_dota_hero_slardar','npc_dota_hero_shredder','npc_dota_hero_broodmother','npc_dota_hero_phantom_lancer','npc_dota_hero_juggernaut','npc_dota_hero_dark_seer','npc_dota_hero_terrorblade','npc_dota_hero_batrider','npc_dota_hero_shadow_demon'}
+heroStrength['npc_dota_hero_treant'] = 2
+
+counters['npc_dota_hero_spectre'] = {'npc_dota_hero_undying','npc_dota_hero_dazzle','npc_dota_hero_chen','npc_dota_hero_life_stealer','npc_dota_hero_antimage','npc_dota_hero_broodmother','npc_dota_hero_treant','npc_dota_hero_necrolyte','npc_dota_hero_alchemist','npc_dota_hero_viper','npc_dota_hero_juggernaut','npc_dota_hero_centaur', 'npc_dota_hero_huskar','npc_dota_hero_lycan','npc_dota_hero_abaddon','npc_dota_hero_witch_doctor'}
+heroStrength['npc_dota_hero_spectre'] = 3
+
+counters['npc_dota_hero_meepo'] = {'npc_dota_hero_leshrac','npc_dota_hero_elder_titan', 'npc_dota_hero_earthshaker','npc_dota_hero_winter_wyvern','npc_dota_hero_shredder','npc_dota_hero_jakiro','npc_dota_hero_sven', 'npc_dota_hero_lich','npc_dota_hero_sand_king','npc_dota_hero_warlock','npc_dota_hero_venomancer','npc_dota_hero_crystal_maiden'}
+heroStrength['npc_dota_hero_meepo'] = 1
+
+counters['npc_dota_hero_phantom_assassin'] = {'npc_dota_hero_shredder','npc_dota_hero_morphling','npc_dota_hero_tinker','npc_dota_hero_razor','npc_dota_hero_troll_warlord', 'npc_dota_hero_omniknight','npc_dota_hero_dragon_knight','npc_dota_hero_meepo','npc_dota_hero_axe'}
+heroStrength['npc_dota_hero_phantom_assassin'] = 3
+
+counters['npc_dota_hero_terrorblade'] = {'npc_dota_hero_shredder','npc_dota_hero_zuus','npc_dota_hero_tinker','npc_dota_hero_axe','npc_dota_hero_ember_spirit','npc_dota_hero_phantom_lancer','npc_dota_hero_dark_seer','npc_dota_hero_warlock','npc_dota_hero_sand_king', 'npc_dota_hero_lich','npc_dota_hero_slark','npc_dota_hero_gyrocopter'}
+heroStrength['npc_dota_hero_terrorblade'] = 2
+
+counters['npc_dota_hero_shredder'] = {'npc_dota_hero_pugna','npc_dota_hero_bloodseeker','npc_dota_hero_ursa','npc_dota_hero_skywrath_mage', 'npc_dota_hero_drow_ranger','npc_dota_hero_silencer','npc_dota_hero_necrolyte','npc_dota_hero_pudge','npc_dota_hero_doom_bringer','npc_dota_hero_faceless_void', 'npc_dota_hero_luna', 'npc_dota_hero_ancient_apparition','npc_dota_hero_obsidian_destroyer','npc_dota_hero_death_prophet'}
+heroStrength['npc_dota_hero_shredder'] = 2
+
+counters['npc_dota_hero_omniknight'] = {'npc_dota_hero_enigma', 'npc_dota_hero_necrolyte', 'npc_dota_hero_obsidian_destroyer','npc_dota_hero_ancient_apparition','npc_dota_hero_luna','npc_dota_hero_lich','npc_dota_hero_abyssal_underlord','npc_dota_hero_faceless_void','npc_dota_hero_undying','npc_dota_hero_grimstroke','npc_dota_hero_huskar', 'npc_dota_hero_skywrath_mage','npc_dota_hero_sand_king','npc_dota_hero_meepo', 'npc_dota_hero_shredder'}
+heroStrength['npc_dota_hero_omniknight'] = 3
+
+counters['npc_dota_hero_spirit_breaker'] = {'npc_dota_hero_necrolyte', 'npc_dota_hero_abyssal_underlord','npc_dota_hero_undying','npc_dota_hero_meepo'}
+heroStrength['npc_dota_hero_spirit_breaker'] = 0
+
+counters['npc_dota_hero_gyrocopter'] = {'npc_dota_hero_spectre', 'npc_dota_hero_warlock','npc_dota_hero_juggernaut','npc_dota_hero_abaddon','npc_dota_hero_antimage','npc_dota_hero_skeleton_king','npc_dota_hero_doom_bringer','npc_dota_hero_tidehunter','npc_dota_hero_bristleback','npc_dota_hero_zuus','npc_dota_hero_tinker','npc_dota_hero_clinkz','npc_dota_hero_arc_warden','npc_dota_hero_pudge','npc_dota_hero_sniper','npc_dota_hero_omniknight','npc_dota_hero_life_stealer'}
+heroStrength['npc_dota_hero_gyrocopter'] = 2
+
+counters['npc_dota_hero_lycan'] = {'npc_dota_hero_naga_siren','npc_dota_hero_bristleback','npc_dota_hero_bloodseeker','npc_dota_hero_sven','npc_dota_hero_troll_warlord', 'npc_dota_hero_phantom_assassin','npc_dota_hero_gyrocopter','npc_dota_hero_kunkka','npc_dota_hero_shredder','npc_dota_hero_slardar','npc_dota_hero_axe','npc_dota_hero_dazzle','npc_dota_hero_earthshaker','npc_dota_hero_tidehunter','npc_dota_hero_meepo','npc_dota_hero_abyssal_underlord','npc_dota_hero_terrorblade','npc_dota_hero_vengefulspirit','npc_dota_hero_crystal_maiden','npc_dota_hero_jakiro'}
+heroStrength['npc_dota_hero_lycan'] = 2
+
+counters['npc_dota_hero_magnataur'] = {'npc_dota_hero_clinkz','npc_dota_hero_bloodseeker','npc_dota_hero_huskar','npc_dota_hero_sniper','npc_dota_hero_doom_bringer'}
+heroStrength['npc_dota_hero_magnataur'] = 2
+
+counters['npc_dota_hero_medusa'] = {'npc_dota_hero_broodmother','npc_dota_hero_sniper','npc_dota_hero_antimage','npc_dota_hero_clinkz','npc_dota_hero_nyx_assassin','npc_dota_hero_huskar','npc_dota_hero_terrorblade','npc_dota_hero_riki','npc_dota_hero_ursa','npc_dota_hero_jakiro'}
+heroStrength['npc_dota_hero_medusa'] = 2
+
+counters['npc_dota_hero_witch_doctor'] = {'npc_dota_hero_morphling','npc_dota_hero_phantom_assassin','npc_dota_hero_phantom_lancer','npc_dota_hero_clinkz','npc_dota_hero_furion','npc_dota_hero_riki','npc_dota_hero_brewmaster','npc_dota_hero_juggernaut','npc_dota_hero_slark','npc_dota_hero_drow_ranger','npc_dota_hero_silencer','npc_dota_hero_warlock'}
+heroStrength['npc_dota_hero_witch_doctor'] = 0
+
+counters['npc_dota_hero_elder_titan'] = {'npc_dota_hero_clinkz','npc_dota_hero_life_stealer','npc_dota_hero_juggernaut','npc_dota_hero_sniper','npc_dota_hero_huskar','npc_dota_hero_dark_seer','npc_dota_hero_skywrath_mage','npc_dota_hero_phantom_assassin'}
+heroStrength['npc_dota_hero_elder_titan'] = 2
+
+counters['npc_dota_hero_silencer'] = {'npc_dota_hero_broodmother','npc_dota_hero_naga_siren','npc_dota_hero_abaddon','npc_dota_hero_phantom_lancer','npc_dota_hero_huskar','npc_dota_hero_lycan','npc_dota_hero_arc_warden','npc_dota_hero_slark','npc_dota_hero_luna','npc_dota_hero_meepo','npc_dota_hero_tidehunter','npc_dota_hero_chaos_knight','npc_dota_hero_juggernaut','npc_dota_hero_spirit_breaker','npc_dota_hero_bloodseeker','npc_dota_hero_skeleton_king','npc_dota_hero_drow_ranger','npc_dota_hero_sniper','npc_dota_hero_brewmaster'}
+heroStrength['npc_dota_hero_silencer'] = 3
+
+counters['npc_dota_hero_enchantress'] = {'npc_dota_hero_naga_siren','npc_dota_hero_phantom_assassin','npc_dota_hero_pudge','npc_dota_hero_morphling','npc_dota_hero_phantom_lancer','npc_dota_hero_batrider','npc_dota_hero_bristleback','npc_dota_hero_crystal_maiden','npc_dota_hero_pugna','npc_dota_hero_furion','npc_dota_hero_ursa','npc_dota_hero_tinker','npc_dota_hero_windrunner','npc_dota_hero_alchemist','npc_dota_hero_techies','npc_dota_hero_nevermore','npc_dota_hero_troll_warlord','npc_dota_hero_skywrath_mage','npc_dota_hero_shadow_shaman','npc_dota_hero_luna','npc_dota_hero_lion','npc_dota_hero_dazzle','npc_dota_hero_zuus'}
+heroStrength['npc_dota_hero_enchantress'] = 1
+
+counters['npc_dota_hero_enigma'] = {'npc_dota_hero_sniper','npc_dota_hero_spectre','npc_dota_hero_medusa','npc_dota_hero_clinkz','npc_dota_hero_riki','npc_dota_hero_death_prophet','npc_dota_hero_warlock','npc_dota_hero_rubick','npc_dota_hero_morphling','npc_dota_hero_bristleback','npc_dota_hero_silencer','npc_dota_hero_juggernaut','npc_dota_hero_abaddon','npc_dota_hero_skeleton_king','npc_dota_hero_phantom_assassin','npc_dota_hero_winter_wyvern','npc_dota_hero_drow_ranger','npc_dota_hero_kunkka','npc_dota_hero_jakiro','npc_dota_hero_skywrath_mage'}
+heroStrength['npc_dota_hero_enigma'] = -1 
+
+counters['npc_dota_hero_phoenix'] = {'npc_dota_hero_drow_ranger','npc_dota_hero_clinkz','npc_dota_hero_juggernaut','npc_dota_hero_huskar','npc_dota_hero_skywrath_mage','npc_dota_hero_silencer','npc_dota_hero_bloodseeker','npc_dota_hero_tidehunter','npc_dota_hero_oracle','npc_dota_hero_antimage'}
+heroStrength['npc_dota_hero_phoenix'] = -1
+
+
+counters['npc_dota_hero_undying'] = {'npc_dota_hero_medusa','npc_dota_hero_clinkz','npc_dota_hero_broodmother','npc_dota_hero_antimage','npc_dota_hero_drow_ranger','npc_dota_hero_weaver','npc_dota_hero_pangolier','npc_dota_hero_sniper',}
+heroStrength[''] = 2
+
+
+--[[
+
+
+
+	'npc_dota_hero_riki',
+	'npc_dota_hero_lycan',
+	'npc_dota_hero_clinkz',
+
+
+counters[''] = {}
+heroStrength[''] = 1
+
+counters[''] = {}
+heroStrength[''] = 1]]--
+
+
+
+function GetHeroStrength(heroName, enemies)
+	local score = 0;
+
+	if heroStrength[heroName] ~= nil then
+	score = heroStrength[heroName];
+	end
+
+	-- am I countered?
+	if counters[heroName] ~= nil then
+	for i, enemyName in pairs(enemies) do
+		for ci, cname in pairs(counters[heroName]) do
+			if cname == enemyName then score = score - 1 - role.GetRoleLevel(enemyName, 'carry') - role.GetRoleLevel(heroName, 'carry') end
+		end
+	end
+	end
+	
+	-- am I counter them?
+	for i, enemyName in pairs(enemies) do
+	if counters[enemyName] ~= nil then
+		 for ci, cname in pairs(counters[enemyName]) do
+		if cname == heroName then score = score + 1 + role.GetRoleLevel(enemyName, 'carry') + role.GetRoleLevel(heroName, 'carry') end
+		 end
+	end
+	end
+	--print("hero str of "..	heroName .. " " .. score)
+	return score
+end
+
+local allBotHeroes = {
+	'npc_dota_hero_pangolier',
+	'npc_dota_hero_dark_willow',
+	'npc_dota_hero_ember_spirit',
+	'npc_dota_hero_earth_spirit',
+	'npc_dota_hero_phoenix',
+	'npc_dota_hero_terrorblade',
+	'npc_dota_hero_morphling',
+	'npc_dota_hero_shredder',
+	'npc_dota_hero_broodmother',
+	'npc_dota_hero_antimage',
+	'npc_dota_hero_dark_seer',
+	'npc_dota_hero_weaver',
+	'npc_dota_hero_obsidian_destroyer',
+	'npc_dota_hero_batrider',
+	'npc_dota_hero_lone_druid',
+	'npc_dota_hero_wisp',
+	'npc_dota_hero_chen',
+	'npc_dota_hero_troll_warlord',
+	'npc_dota_hero_alchemist',
+	'npc_dota_hero_tinker',
+	'npc_dota_hero_furion',
+	'npc_dota_hero_templar_assassin',
+	'npc_dota_hero_rubick',
+	'npc_dota_hero_keeper_of_the_light',
+	'npc_dota_hero_ancient_apparition',
+	'npc_dota_hero_mirana',
+	'npc_dota_hero_medusa',
+	'npc_dota_hero_spectre',
+	'npc_dota_hero_enigma',
+	'npc_dota_hero_visage',
+	'npc_dota_hero_riki',
+	'npc_dota_hero_lycan',
+	'npc_dota_hero_clinkz',
+	'npc_dota_hero_techies',
+	'npc_dota_hero_winter_wyvern',
+	'npc_dota_hero_pugna',
+	'npc_dota_hero_queenofpain',
+	'npc_dota_hero_silencer',
+	'npc_dota_hero_leshrac',
+	'npc_dota_hero_enchantress',
+	'npc_dota_hero_nyx_assassin',
+	'npc_dota_hero_storm_spirit',
+	'npc_dota_hero_abaddon',
+	'npc_dota_hero_abyssal_underlord',
+	'npc_dota_hero_arc_warden',
+	'npc_dota_hero_spirit_breaker',
+	'npc_dota_hero_axe',
+	'npc_dota_hero_bane',
+	'npc_dota_hero_beastmaster',
+	'npc_dota_hero_bloodseeker',
+	'npc_dota_hero_bounty_hunter',
+	'npc_dota_hero_brewmaster',
+	'npc_dota_hero_bristleback',
+	'npc_dota_hero_centaur',
+	'npc_dota_hero_chaos_knight',
+	'npc_dota_hero_crystal_maiden',
+	'npc_dota_hero_dazzle',
+	'npc_dota_hero_death_prophet',
+	'npc_dota_hero_disruptor',
+	'npc_dota_hero_doom_bringer',
+	'npc_dota_hero_dragon_knight',
+	'npc_dota_hero_drow_ranger',
+	'npc_dota_hero_earthshaker',
+	'npc_dota_hero_elder_titan',
+	'npc_dota_hero_faceless_void',
+	'npc_dota_hero_grimstroke',
+	'npc_dota_hero_gyrocopter',
+	'npc_dota_hero_huskar',
+	'npc_dota_hero_invoker',
+	'npc_dota_hero_jakiro',
+	'npc_dota_hero_juggernaut',
+	'npc_dota_hero_kunkka',
+	'npc_dota_hero_legion_commander',
+	'npc_dota_hero_lich',
+	'npc_dota_hero_life_stealer',
+	'npc_dota_hero_lina',
+	'npc_dota_hero_lion',
+	'npc_dota_hero_luna',
+	'npc_dota_hero_magnataur',
+	'npc_dota_hero_meepo',
+	'npc_dota_hero_monkey_king',
+	'npc_dota_hero_naga_siren',
+	'npc_dota_hero_necrolyte',
+	'npc_dota_hero_nevermore',
+	'npc_dota_hero_night_stalker',
+	'npc_dota_hero_ogre_magi',
+	'npc_dota_hero_omniknight',
+	'npc_dota_hero_oracle',
+	'npc_dota_hero_phantom_assassin',
+	'npc_dota_hero_phantom_lancer',
+	'npc_dota_hero_puck',
+	'npc_dota_hero_pudge',
+	'npc_dota_hero_rattletrap',
+	'npc_dota_hero_razor',
+	'npc_dota_hero_sand_king',
+	'npc_dota_hero_shadow_demon',
+	'npc_dota_hero_shadow_shaman',
+	'npc_dota_hero_skeleton_king',
+	'npc_dota_hero_skywrath_mage',
+	'npc_dota_hero_slardar',
+	'npc_dota_hero_slark',
+	'npc_dota_hero_sniper',
+	'npc_dota_hero_sven',
+	'npc_dota_hero_tidehunter',
+	'npc_dota_hero_tiny',
+	'npc_dota_hero_treant',
+	'npc_dota_hero_treant',
+	'npc_dota_hero_tusk',
+	'npc_dota_hero_undying',
+	'npc_dota_hero_ursa',
+	'npc_dota_hero_vengefulspirit',
+	'npc_dota_hero_venomancer',
+	'npc_dota_hero_viper',
+	'npc_dota_hero_warlock',
+	'npc_dota_hero_windrunner',
+	'npc_dota_hero_witch_doctor',
+	'npc_dota_hero_zuus'
+};
+
+function GetNthBestHero(N)
+	local enemies = {nil, 'npc_dota_hero_antimage', "npc_dota_hero_arc_warden", 'npc_dota_hero_ancient_apparition', 'npc_dota_hero_bristleback'}
+	local heroScores = {}
+	
+	for i, hero in pairs(allBotHeroes) do
+		heroScores[#heroScores+1] = { hero , GetHeroStrength(hero, enemies), randomValues[hero] }
+	end
+	
+	table.sort(heroScores, strCompare)
+	
+	--[[for i, hero_score in pairs(heroScores) do
+		print(hero_score[1] .. " " .. hero_score[2])
+	end]]--
+	
+	return heroScores[N][1]
+end
+
+function strCompare(a,b)
+	if a[2] == b[2] and a[3] == b[3] then
+	return a[1] > b[1]
+	end
+	
+	if a[2] == b[2]	then
+	return a[3] > b[3]
+	end
+	
+	return a[2] > b[2]
+end
+
+function FillRandomValues()
+	for i, hero in pairs(allBotHeroes) do
+		randomValues[hero] = RandomInt(1,100)
+	end
+end
+
+
+function test()
+	mukk = {nil, 'npc_dota_hero_antimage', "npc_dota_hero_arc_warden", 'npc_dota_hero_ancient_apparition', 'npc_dota_hero_bristleback'}
+	GetHeroStrength('npc_dota_hero_necrolyte', mukk)
+	GetHeroStrength('npc_dota_hero_bristleback', mukk)
+	GetHeroStrength('npc_dota_hero_chaos_knight', mukk)
+	
+	print(GetNthBestHero(1));
+	print(GetNthBestHero(2));
+	print(GetNthBestHero(3));
+	print(GetNthBestHero(4));
+end
+
+--test()
+FillRandomValues()
+

--- a/hero_selection.lua
+++ b/hero_selection.lua
@@ -1,11 +1,10 @@
 local role = require(GetScriptDirectory() .. "/RoleUtility");
 local bnUtil = require(GetScriptDirectory() .. "/BotNameUtility");
+local counters = require(GetScriptDirectory() .. "/counters");
 local hero_roles = role["hero_roles"];
 -- mandate that the bots will pick these heroes - for testing purposes
 local requiredHeroes = {
-	"npc_dota_hero_phantom_assassin",
-	"npc_dota_hero_sniper"
-
+	"--npc_dota_hero_wisp"
 };
 
 local UnImplementedHeroes = {
@@ -22,7 +21,7 @@ end
 -- quickMode eliminates the 30s delay before picks begin
 -- it also eliminates the delay between bot picks
 local quickMode = false;
-local testMode =  false;
+local testMode =	false;
 
 local allBotHeroes = {
 	'npc_dota_hero_pangolier',
@@ -40,8 +39,8 @@ local allBotHeroes = {
 	'npc_dota_hero_obsidian_destroyer',
 	'npc_dota_hero_batrider',
 	'npc_dota_hero_lone_druid',
-    'npc_dota_hero_wisp',
-    'npc_dota_hero_chen',
+	'npc_dota_hero_wisp',
+	'npc_dota_hero_chen',
 	'npc_dota_hero_troll_warlord',
 	'npc_dota_hero_alchemist',
 	'npc_dota_hero_tinker',
@@ -71,76 +70,77 @@ local allBotHeroes = {
 	'npc_dota_hero_abyssal_underlord',
 	'npc_dota_hero_arc_warden',
 	'npc_dota_hero_spirit_breaker',
-        'npc_dota_hero_axe',
-        'npc_dota_hero_bane',
+	'npc_dota_hero_axe',
+	'npc_dota_hero_bane',
 	'npc_dota_hero_beastmaster',
-        'npc_dota_hero_bloodseeker',
-        'npc_dota_hero_bounty_hunter',
+	'npc_dota_hero_bloodseeker',
+	'npc_dota_hero_bounty_hunter',
 	'npc_dota_hero_brewmaster',
-        'npc_dota_hero_bristleback',
+	'npc_dota_hero_bristleback',
 	'npc_dota_hero_centaur',
-        'npc_dota_hero_chaos_knight',
-        'npc_dota_hero_crystal_maiden',
-        'npc_dota_hero_dazzle',
-        'npc_dota_hero_death_prophet',
+	'npc_dota_hero_chaos_knight',
+	'npc_dota_hero_crystal_maiden',
+	'npc_dota_hero_dazzle',
+	'npc_dota_hero_death_prophet',
 	'npc_dota_hero_disruptor',
 	'npc_dota_hero_doom_bringer',
-        'npc_dota_hero_dragon_knight',
-        'npc_dota_hero_drow_ranger',
-        'npc_dota_hero_earthshaker',
+	'npc_dota_hero_dragon_knight',
+	'npc_dota_hero_drow_ranger',
+	'npc_dota_hero_earthshaker',
 	'npc_dota_hero_elder_titan',
 	'npc_dota_hero_faceless_void',
 	'npc_dota_hero_grimstroke',
 	'npc_dota_hero_gyrocopter',
 	'npc_dota_hero_huskar',
-    'npc_dota_hero_invoker',
-        'npc_dota_hero_jakiro',
-        'npc_dota_hero_juggernaut',
-        'npc_dota_hero_kunkka',
+	'npc_dota_hero_invoker',
+	'npc_dota_hero_jakiro',
+	'npc_dota_hero_juggernaut',
+	'npc_dota_hero_kunkka',
 	'npc_dota_hero_legion_commander',
-        'npc_dota_hero_lich',
+	'npc_dota_hero_lich',
 	'npc_dota_hero_life_stealer',
-        'npc_dota_hero_lina',
-        'npc_dota_hero_lion',
-        'npc_dota_hero_luna',
+	'npc_dota_hero_lina',
+	'npc_dota_hero_lion',
+	'npc_dota_hero_luna',
 	'npc_dota_hero_magnataur',
-    'npc_dota_hero_meepo',
+	'npc_dota_hero_meepo',
 	'npc_dota_hero_monkey_king',
 	'npc_dota_hero_naga_siren',
-        'npc_dota_hero_necrolyte',
-        'npc_dota_hero_nevermore',
+	'npc_dota_hero_necrolyte',
+	'npc_dota_hero_nevermore',
 	'npc_dota_hero_night_stalker',
 	'npc_dota_hero_ogre_magi',
-        'npc_dota_hero_omniknight',
-        'npc_dota_hero_oracle',
-        'npc_dota_hero_phantom_assassin',
+	'npc_dota_hero_omniknight',
+	'npc_dota_hero_oracle',
+	'npc_dota_hero_phantom_assassin',
 	'npc_dota_hero_phantom_lancer',
-    'npc_dota_hero_puck',
-        'npc_dota_hero_pudge',
-    'npc_dota_hero_rattletrap',
-        'npc_dota_hero_razor',
-        'npc_dota_hero_sand_king',
+	'npc_dota_hero_puck',
+	'npc_dota_hero_pudge',
+	'npc_dota_hero_rattletrap',
+	'npc_dota_hero_razor',
+	'npc_dota_hero_sand_king',
 	'npc_dota_hero_shadow_demon',
 	'npc_dota_hero_shadow_shaman',
-        'npc_dota_hero_skeleton_king',
-        'npc_dota_hero_skywrath_mage',
+	'npc_dota_hero_skeleton_king',
+	'npc_dota_hero_skywrath_mage',
 	'npc_dota_hero_slardar',
 	'npc_dota_hero_slark',
-        'npc_dota_hero_sniper',
-        'npc_dota_hero_sven',
-        'npc_dota_hero_tidehunter',
-        'npc_dota_hero_tiny',
+	'npc_dota_hero_sniper',
+	'npc_dota_hero_sven',
+	'npc_dota_hero_tidehunter',
+	'npc_dota_hero_tiny',
+	'npc_dota_hero_treant',
 	'npc_dota_hero_treant',
 	'npc_dota_hero_tusk',
 	'npc_dota_hero_undying',
 	'npc_dota_hero_ursa',
-        'npc_dota_hero_vengefulspirit',
+	'npc_dota_hero_vengefulspirit',
 	'npc_dota_hero_venomancer',
-        'npc_dota_hero_viper',
-        'npc_dota_hero_warlock',
-        'npc_dota_hero_windrunner',
-        'npc_dota_hero_witch_doctor',
-        'npc_dota_hero_zuus'
+	'npc_dota_hero_viper',
+	'npc_dota_hero_warlock',
+	'npc_dota_hero_windrunner',
+	'npc_dota_hero_witch_doctor',
+	'npc_dota_hero_zuus'
 };
 
 local picks = {};
@@ -168,6 +168,14 @@ local CMTestMode = false;
 local UnavailableHeroes = {
 
 }
+local RadiantUnavailableHeroes = {
+
+}
+local DireUnavailableHeroes = {
+
+}
+
+
 local HeroLanes = {
 	[1] = LANE_MID,
 	[2] = LANE_TOP,
@@ -183,7 +191,7 @@ local humanPick = {};
 --function to get hero name that match the expression
 function GetHumanChatHero(name)
 	if name == nil then return ""; end	
-	for _,hero in  pairs(allBotHeroes) do
+	for _,hero in	pairs(allBotHeroes) do
 		if string.find(hero, name) then
 			return hero;
 		end
@@ -233,7 +241,7 @@ function Think()
 		MidOnlyLogic();	
 	elseif GetGameMode() == GAMEMODE_1V1MID then
 		OneVsOneLogic();		
-	elseif  GetGameMode() == GAMEMODE_SD then
+	elseif	GetGameMode() == GAMEMODE_SD then
 		if GetGameState() == GAME_STATE_HERO_SELECTION then
 			InstallChatCallback(function (attr) SelectHeroChatCallback(attr.player_id, attr.string, attr.team_only); end);
 		end
@@ -303,15 +311,15 @@ local humanInRad1Slot = nil;
 
 function TurboModeLogic() 
 	
-	if #GetTeamPlayers(GetTeam()) < 5 or #GetTeamPlayers(GetOpposingTeam()) < 5 then return end  
+	if #GetTeamPlayers(GetTeam()) < 5 or #GetTeamPlayers(GetOpposingTeam()) < 5 then return end	
 	
 	
 	if humanInRad1Slot == nil then humanInRad1Slot = IsHumanPlayerInRadiant1Slot() return end
 	
 	--print(tostring(GetGameMode()).."=>"..tostring(GetGameState())..":"..tostring(DotaTime( ))..":"..tostring(GetHeroPickState()))
 	if GetHeroPickState() == 55 and ( ( humanInRad1Slot == true and IsHumanDonePickingFirstSlot() and DotaTime() > -10 and DotaTime() < -5 ) 
-	   or ( humanInRad1Slot == false and GameTime() > 10  and DotaTime() > -10 and DotaTime() < -5 ) ) 
-    then
+		or ( humanInRad1Slot == false and GameTime() > 12	and DotaTime() > -10 and DotaTime() < -5 ) ) 
+	then
 		for i,id in pairs(GetTeamPlayers(GetTeam())) 
 		do 
 			if IsPlayerBot(id) and IsPlayerInHeroSelectionControl(id) and GetSelectedHeroName(id) == "" 
@@ -364,7 +372,7 @@ function OneVsOneLogic()
 				hero = GetRandomHero();
 			end
 			if hero ~= nil then
-				SelectHero(i, hero); 
+				SelectHero(i, hero);
 				oboselect = true;
 			end
 			return
@@ -387,16 +395,29 @@ function AllPickLogic()
 	if not CanPick() then return end;
 	 
 	 local idx = 0;
-	 for _,i in pairs(GetTeamPlayers(GetTeam())) 
+	local idxArray = {2,3,4,1,0}; 
+	local roleNameArray = {"sup","sup","off","safe","mid"}
+	
+	if GetTeam() == TEAM_RADIANT then
+	 idxArray = { 2,3,1,4,0};
+	end
+	
+
+	local teamPlayers = GetTeamPlayers(GetTeam());
+	--teamPlayers = Shuffle(teamPlayers);
+	 for _,i in pairs(teamPlayers)
 	 do 
-		if IsPlayerBot(i) and IsPlayerInHeroSelectionControl(i) and GetSelectedHeroName(i) == "" 
+	local j = teamPlayers[idxArray[idx+1]+1];
+		if IsPlayerBot(j) and IsPlayerInHeroSelectionControl(j) and GetSelectedHeroName(j) == "" 
 		then 
 			if testMode then
 				hero = GetRandomHero() 
 			else
-				hero = PickRightHero(idx) 
+--print("choosing hero for slot " .. idxArray[idx+1] .. " role: " .. roleNameArray[idx+1])
+				hero = PickRightHero(idxArray[idx+1]) 
 			end
-			SelectHero(i, hero); 
+--print("select hero " .. hero .. " for teamplayer j = " .. j)
+			SelectHero(j, hero); 
 			PickTime = GameTime();
 			RandomTime = 0;
 			return;
@@ -405,10 +426,21 @@ function AllPickLogic()
 	end 
 	idx = 0;
 end
+
+function Shuffle(tbl)
+	size = #tbl
+	for i = size, 1, -1 do
+	local rand = RandomInt(1,size)
+	tbl[i], tbl[rand] = tbl[rand], tbl[i]
+	end
+	return tbl
+end
+
 --Delay for picking between player in team
 function CanPick()
-	if not IsHumanPresentInGame() and RandomTime == 0 then RandomTime = RandomInt((30/5)/2,30/5); end
-	if GameTime() > 60 or IsHumansDonePicking() then return true end
+	--if not IsHumanPresentInGame() and RandomTime == 0 then RandomTime = RandomInt(8,10); end
+	RandomTime = RandomInt(8,12);
+	if GameTime() > 60 then return true end --[[or IsHumansDonePicking()]]--
 	if RandomTime ~= 0 and GameTime() >= PickTime + RandomTime then return true end
 	return false;
 end
@@ -420,8 +452,8 @@ end
 local lastState = -1;
 function CaptainModeLogic()
 	if (GetGameState() ~= GAME_STATE_HERO_SELECTION) then
-        return
-    end
+		return
+	end
 	if not CMTestMode then
 		if NeededTime == 29 then
 			NeededTime = RandomInt( Min, Max );
@@ -458,23 +490,23 @@ end
 --Check if human player exist in team
 function IsHumanPlayerExist()
 	local Players = GetTeamPlayers(GetTeam())
-    for _,id in pairs(Players) do
-        if not IsPlayerBot(id) then
+	for _,id in pairs(Players) do
+		if not IsPlayerBot(id) then
 			return true;
-        end
-    end
+		end
+	end
 	return false;
 end
 --Get the first bot to be the captain
 function GetFirstBot()
 	local BotId = nil;
 	local Players = GetTeamPlayers(GetTeam())
-    for _,id in pairs(Players) do
-        if IsPlayerBot(id) then
+	for _,id in pairs(Players) do
+		if IsPlayerBot(id) then
 			BotId = id;
 			return BotId;
-        end
-    end
+		end
+	end
 	return BotId;
 end
 --Ban hero function
@@ -552,6 +584,25 @@ function IsUnavailableHero(name)
 			return true;
 		end	
 	end
+	
+	if GetTeam() == TEAM_RADIANT then
+		for _,uh in pairs(RadiantUnavailableHeroes)
+		do
+			if name == uh then
+				return true;
+			end	
+		end
+	end
+	
+	if GetTeam() == TEAM_DIRE then
+		for _,uh in pairs(DireUnavailableHeroes)
+		do
+			if name == uh then
+				return true;
+			end	
+		end
+	end
+	
 	return false;
 end
 --Check if a hero hasn't implemented yet
@@ -569,21 +620,21 @@ function RandomHero()
 	local hero = allBotHeroes[RandomInt(1, #allBotHeroes)];
 	while ( IsUnavailableHero(hero) or IsCMPickedHero(GetTeam(), hero) or IsCMPickedHero(GetOpposingTeam(), hero) or IsCMBannedHero(hero) ) 
 	do
-        hero = allBotHeroes[RandomInt(1, #allBotHeroes)];
-    end
+		hero = allBotHeroes[RandomInt(1, #allBotHeroes)];
+	end
 	return hero;
 end
 --Check if the human already pick the hero in captain's mode
 function WasHumansDonePicking()
 	local Players = GetTeamPlayers(GetTeam())
-    for _,id in pairs(Players) 
+	for _,id in pairs(Players) 
 	do
-        if not IsPlayerBot(id) then
+		if not IsPlayerBot(id) then
 			if GetSelectedHeroName(id) == nil or GetSelectedHeroName(id) == "" then
 				return false;
 			end	
-        end
-    end
+		end
+	end
 	return true;
 end
 --Select the rest of the heroes that the human players don't pick in captain's mode
@@ -595,7 +646,7 @@ function SelectsHero()
 		
 		for _,id in pairs(Players) 
 		do
-			local hero_name =  GetSelectedHeroName(id);
+			local hero_name =	GetSelectedHeroName(id);
 			if hero_name ~= nil and hero_name ~= "" then
 				UpdateSelectedHeroes(hero_name)
 				print(hero_name.." Removed")
@@ -644,7 +695,7 @@ end
 function AllRandomLogic()
 	for i,id in pairs(GetTeamPlayers(GetTeam())) 
 	 do 
-		if  GetHeroPickState() == HEROPICK_STATE_AR_SELECT and IsPlayerInHeroSelectionControl(id) and GetSelectedHeroName(id) == ""
+		if	GetHeroPickState() == HEROPICK_STATE_AR_SELECT and IsPlayerInHeroSelectionControl(id) and GetSelectedHeroName(id) == ""
 		then 
 			hero = GetRandomHero(); 
 			SelectHero(id, hero); 
@@ -663,10 +714,10 @@ function MidOnlyLogic()
 		if IsHumansDonePicking() then
 			if IsHumanPlayerExist() then
 				local selectedHero = GetSelectedHumanHero(GetTeam())
-				if selectedHero ~= "" and  selectedHero ~= nil then
+				if selectedHero ~= "" and	selectedHero ~= nil then
 					for i,id in pairs(GetTeamPlayers(GetTeam())) 
 					 do 
-						if  GetHeroPickState() == HEROPICK_STATE_AP_SELECT and IsPlayerBot(id) and IsPlayerInHeroSelectionControl(id) and GetSelectedHeroName(id) == ""
+						if	GetHeroPickState() == HEROPICK_STATE_AP_SELECT and IsPlayerBot(id) and IsPlayerInHeroSelectionControl(id) and GetSelectedHeroName(id) == ""
 						then 
 							SelectHero(id, selectedHero); 
 							return;
@@ -675,10 +726,10 @@ function MidOnlyLogic()
 				end 
 			else
 				local selectedHero = GetSelectedHumanHero(GetOpposingTeam())
-				if selectedHero ~= "" and  selectedHero ~= nil then
+				if selectedHero ~= "" and	selectedHero ~= nil then
 					for i,id in pairs(GetTeamPlayers(GetTeam())) 
 					do 
-						if  GetHeroPickState() == HEROPICK_STATE_AP_SELECT and IsPlayerBot(id) and IsPlayerInHeroSelectionControl(id) and GetSelectedHeroName(id) == ""
+						if	GetHeroPickState() == HEROPICK_STATE_AP_SELECT and IsPlayerBot(id) and IsPlayerInHeroSelectionControl(id) and GetSelectedHeroName(id) == ""
 						then 
 							SelectHero(id, selectedHero); 
 							return;
@@ -695,7 +746,7 @@ function MidOnlyLogic()
 				local selectedHero = GetOpposingTeamSelectedHero()
 				for i,id in pairs(GetTeamPlayers(GetTeam())) 
 				do 
-					if  GetHeroPickState() == HEROPICK_STATE_AP_SELECT and IsPlayerBot(id) and IsPlayerInHeroSelectionControl(id) and GetSelectedHeroName(id) == ""
+					if	GetHeroPickState() == HEROPICK_STATE_AP_SELECT and IsPlayerBot(id) and IsPlayerInHeroSelectionControl(id) and GetSelectedHeroName(id) == ""
 					then 
 						SelectHero(id, selectedHero); 
 						return;
@@ -706,7 +757,7 @@ function MidOnlyLogic()
 			local selectedHero = SetRandomHero();
 			for i,id in pairs(GetTeamPlayers(GetTeam())) 
 			do 
-				if  GetHeroPickState() == HEROPICK_STATE_AP_SELECT and IsPlayerBot(id) and IsPlayerInHeroSelectionControl(id) and GetSelectedHeroName(id) == ""
+				if	GetHeroPickState() == HEROPICK_STATE_AP_SELECT and IsPlayerBot(id) and IsPlayerInHeroSelectionControl(id) and GetSelectedHeroName(id) == ""
 				then 
 					SelectHero(id, selectedHero); 
 					return;
@@ -721,7 +772,7 @@ function GetSelectedHumanHero(team)
 	do 
 		if not IsPlayerBot(id) and GetSelectedHeroName(id) ~= ""
 		then 
-			return  GetSelectedHeroName(id);
+			return	GetSelectedHeroName(id);
 		end
 	end 
 end
@@ -778,31 +829,39 @@ end
 ----------------------------------------------------HERO SELECTION UTILITY FUNCTION------------------------------
 --Pick hero based on role
 function PickRightHero(slot)
-	local initHero = GetRandomHero();
+	local N = 1;
+	local initHero = GetNthBestHero(N);
 	local Team = GetTeam();
+	N = N + 1;
+	
 	if slot == 0 then
 		while not role.CanBeMidlaner(initHero) do
-			initHero = GetRandomHero();
+			initHero = GetNthBestHero(N);
+		N = N + 1;
 		end
 	elseif slot == 1 then
 		while ( Team == TEAM_RADIANT and not role.CanBeOfflaner(initHero) ) or 
-			  ( Team == TEAM_DIRE and not role.CanBeSafeLaneCarry(initHero) ) 
+				( Team == TEAM_DIRE and not role.CanBeSafeLaneCarry(initHero) ) 
 		do
-			initHero = GetRandomHero();
+			initHero = GetNthBestHero(N);
+		N = N + 1;
 		end
 	elseif slot == 2 then
 		while not role.CanBeSupport(initHero) do
-			initHero = GetRandomHero();
+			initHero = GetNthBestHero(N);
+		N = N + 1;
 		end
 	elseif slot == 3 then
 		while not role.CanBeSupport(initHero) do
-			initHero = GetRandomHero();
+			initHero = GetNthBestHero(N);
+		N = N + 1;
 		end
 	elseif slot == 4 then
 		while ( Team == TEAM_RADIANT and not role.CanBeSafeLaneCarry(initHero) ) or 
-			  ( Team == TEAM_DIRE and not role.CanBeOfflaner(initHero) )
+				( Team == TEAM_DIRE and not role.CanBeOfflaner(initHero) )
 		do
-			initHero = GetRandomHero();
+			initHero = GetNthBestHero(N);
+		N = N + 1;
 		end
 	end
 	return initHero;
@@ -828,38 +887,38 @@ function IsHumansDonePicking()
 end
 --Pick hero function
 function PickHero(slot)
-  local hero = GetRandomHero();
-  SelectHero(slot, hero);
+	local hero = GetRandomHero();
+	SelectHero(slot, hero);
 end
 -- haven't found a better way to get already-picked heroes than just looping over all the players
 function GetPicks()
 	local selectedHeroes = {};
-    local pickedSlots = {};
+	local pickedSlots = {};
 	for _,i in pairs(GetTeamPlayers(GetTeam())) 
 	do 
 		if GetSelectedHeroName(i) ~= "" then 
-			selectedHeroes[i] =  GetSelectedHeroName(i);
+			selectedHeroes[i] =	GetSelectedHeroName(i);
 		end 
 	end 
 	-- check dire 
 	for _,i in pairs(GetTeamPlayers(GetOpposingTeam())) 
 	do 
 		if GetSelectedHeroName(i) ~= "" then 
-			selectedHeroes[i] =  GetSelectedHeroName(i);
+			selectedHeroes[i] =	GetSelectedHeroName(i);
 		end 
 	end 
-    return selectedHeroes;
+	return selectedHeroes;
 end
 -- first, check the list of required heroes and pick from those
 -- then try the whole bot pool
 function GetRandomHero()
-    local hero;
-    local picks = GetPicks();
-    local selectedHeroes = {};
+	local hero;
+	local picks = GetPicks();
+	local selectedHeroes = {};
 	
-    for slot, hero in pairs(picks) do
+	for slot, hero in pairs(picks) do
 		selectedHeroes[hero] = true;
-    end
+	end
 
 	if testMode then
 		hero = requiredHeroes[RandomInt(1, #requiredHeroes)];
@@ -868,14 +927,61 @@ function GetRandomHero()
 	end
 	
 	if (hero == nil) then
-        hero = allBotHeroes[RandomInt(1, #allBotHeroes)];
-    end
+		hero = allBotHeroes[RandomInt(1, #allBotHeroes)];
+	end
 
-    while ( selectedHeroes[hero] == true ) do
-        hero = allBotHeroes[RandomInt(1, #allBotHeroes)];
-    end
+	while ( selectedHeroes[hero] == true or IsUnavailableHero(hero)) do
+		hero = allBotHeroes[RandomInt(1, #allBotHeroes)];
+	end
 
-    return hero;
+	return hero;
+
+end
+
+function GetNthBestHero(N)
+	
+--print("GetNthBestHero " .. N)
+	
+	local picks = GetPicks();
+	local selectedHeroes = {};
+	
+	for slot, hero in pairs(picks) do
+		selectedHeroes[hero] = true;
+	end
+	
+	local enemies = {}
+	
+	for i,id in pairs(GetTeamPlayers(GetOpposingTeam())) do
+			if GetSelectedHeroName(id) ~= nil and GetSelectedHeroName(id) ~= "" then
+		enemies[#enemies+1] = GetSelectedHeroName(id)
+		end
+	end
+	
+	
+	local heroScores = {}
+	
+	for i, hero in pairs(allBotHeroes) do
+		if ( selectedHeroes[hero] == nil and IsUnavailableHero(hero) == false ) then
+		heroScores[#heroScores+1] = { hero , GetHeroStrength(hero, enemies), randomValues[hero] }
+		end
+	end
+	
+	table.sort(heroScores, strCompare)
+	
+	--print(N ..". best hero: " .. heroScores[N][1] .. "(".. heroScores[N][2]	.. ")" .. " rval: " .. heroScores[N][3])
+	return heroScores[N][1]
+end
+
+function strCompare(a,b)
+	if a[2] == b[2] and a[3] == b[3] then
+	return a[1] > b[1]
+	end
+	
+	if a[2] == b[2]	then
+	return a[3] > b[3]
+	end
+	
+	return a[2] > b[2]
 end
 
 local chatLanes = {};
@@ -903,7 +1009,7 @@ function SelectLaneChatCallback(PlayerID, ChatText, bTeamOnly)
 end
 
 ---------------------------------------------------------LANE ASSIGNMENT-----------------------------------------------------------------
-function UpdateLaneAssignments()    
+function UpdateLaneAssignments()	
 	if GetGameMode() == GAMEMODE_AP or GetGameMode() == GAMEMODE_TM or GetGameMode() == GAMEMODE_SD then
 		--print("AP Lane Assignment")
 		if GetGameState() == GAME_STATE_STRATEGY_TIME or GetGameState() == GAME_STATE_PRE_GAME then
@@ -924,101 +1030,101 @@ function UpdateLaneAssignments()
 	elseif GetGameMode() == GAMEMODE_1V1MID then
 		return OneVsOneLaneAssignment()			
 	end
-   
+	
 end
 ---------------------------------------------------------ALL PICK LANE ASSIGNMENT------------------------------------------------------------
 function APLaneAssignment()
 
 	 local lanecount = {
-        [LANE_NONE] = 5,
-        [LANE_MID] = 1,
-        [LANE_TOP] = 2,
-        [LANE_BOT] = 2,
-    };
+		[LANE_NONE] = 5,
+		[LANE_MID] = 1,
+		[LANE_TOP] = 2,
+		[LANE_BOT] = 2,
+	};
 
-    local lanes = {
-        [1] = LANE_MID,
-        [2] = LANE_TOP,
-        [3] = LANE_TOP,
-        [4] = LANE_BOT,
-        [5] = LANE_BOT,
-        };
+	local lanes = {
+		[1] = LANE_MID,
+		[2] = LANE_TOP,
+		[3] = LANE_TOP,
+		[4] = LANE_BOT,
+		[5] = LANE_BOT,
+		};
 
-    local playercount = 0
+	local playercount = 0
 
-    if ( GetTeam() == TEAM_RADIANT )
-    then 
-        local ids = GetTeamPlayers(TEAM_RADIANT)
-        for i,v in pairs(ids) do
-            if not IsPlayerBot(v) then
-                playercount = playercount + 1
-            end
-        end
-        for i=1,playercount do
-            local lane = GetLane( TEAM_RADIANT,GetTeamMember( i ) )
-            lanecount[lane] = lanecount[lane] - 1
-            lanes[i] = lane 
-        end
+	if ( GetTeam() == TEAM_RADIANT )
+	then 
+		local ids = GetTeamPlayers(TEAM_RADIANT)
+		for i,v in pairs(ids) do
+			if not IsPlayerBot(v) then
+				playercount = playercount + 1
+			end
+		end
+		for i=1,playercount do
+			local lane = GetLane( TEAM_RADIANT,GetTeamMember( i ) )
+			lanecount[lane] = lanecount[lane] - 1
+			lanes[i] = lane 
+		end
 	
-        for i=(playercount + 1), 5 do
-            if lanecount[LANE_MID] > 0 then
-                lanes[i] = LANE_MID
-                lanecount[LANE_MID] = lanecount[LANE_MID] - 1
-            elseif lanecount[LANE_TOP] > 0 then
-                lanes[i] = LANE_TOP
-                lanecount[LANE_TOP] = lanecount[LANE_TOP] - 1
-            else
-                lanes[i] = LANE_BOT
-            end
-        end
-        return lanes
-    elseif ( GetTeam() == TEAM_DIRE )
-    then
-        local ids = GetTeamPlayers(TEAM_DIRE)
-        for i,v in pairs(ids) do
-            --print(tostring(IsPlayerBot(v)))
-            if not IsPlayerBot(v) then
-                playercount = playercount + 1
-            end
-        end
-        for i=1,playercount do
-            local lane = GetLane( TEAM_DIRE, GetTeamMember( i ) )
-            lanecount[lane] = lanecount[lane] - 1
-            lanes[i] = lane 
-        end
+		for i=(playercount + 1), 5 do
+			if lanecount[LANE_MID] > 0 then
+				lanes[i] = LANE_MID
+				lanecount[LANE_MID] = lanecount[LANE_MID] - 1
+			elseif lanecount[LANE_TOP] > 0 then
+				lanes[i] = LANE_TOP
+				lanecount[LANE_TOP] = lanecount[LANE_TOP] - 1
+			else
+				lanes[i] = LANE_BOT
+			end
+		end
+		return lanes
+	elseif ( GetTeam() == TEAM_DIRE )
+	then
+		local ids = GetTeamPlayers(TEAM_DIRE)
+		for i,v in pairs(ids) do
+			--print(tostring(IsPlayerBot(v)))
+			if not IsPlayerBot(v) then
+				playercount = playercount + 1
+			end
+		end
+		for i=1,playercount do
+			local lane = GetLane( TEAM_DIRE, GetTeamMember( i ) )
+			lanecount[lane] = lanecount[lane] - 1
+			lanes[i] = lane 
+		end
 
-        for i=(playercount + 1), 5 do
-            if lanecount[LANE_MID] > 0 then
-                lanes[i] = LANE_MID
-                lanecount[LANE_MID] = lanecount[LANE_MID] - 1
-            elseif lanecount[LANE_TOP] > 0 then
-                lanes[i] = LANE_TOP
-                lanecount[LANE_TOP] = lanecount[LANE_TOP] - 1
-            else
-                lanes[i] = LANE_BOT
-            end
-        end
-        --utils.print_r(lanes)
-        return lanes
-    end
+		for i=(playercount + 1), 5 do
+			if lanecount[LANE_MID] > 0 then
+				lanes[i] = LANE_MID
+				lanecount[LANE_MID] = lanecount[LANE_MID] - 1
+			elseif lanecount[LANE_TOP] > 0 then
+				lanes[i] = LANE_TOP
+				lanecount[LANE_TOP] = lanecount[LANE_TOP] - 1
+			else
+				lanes[i] = LANE_BOT
+			end
+		end
+		--utils.print_r(lanes)
+		return lanes
+	end
 
 end
 
 function GetLane( nTeam ,hHero )
-        local vBot = GetLaneFrontLocation(nTeam, LANE_BOT, 0)
-        local vTop = GetLaneFrontLocation(nTeam, LANE_TOP, 0)
-        local vMid = GetLaneFrontLocation(nTeam, LANE_MID, 0)
-        --print(GetUnitToLocationDistance(hHero, vMid))
-        if GetUnitToLocationDistance(hHero, vBot) < 2500 then
-            return LANE_BOT
-        end
-        if GetUnitToLocationDistance(hHero, vTop) < 2500 then
-            return LANE_TOP
-        end
-        if GetUnitToLocationDistance(hHero, vMid) < 2500 then
-            return LANE_MID
-        end
-        return LANE_NONE
+		local vBot = GetLaneFrontLocation(nTeam, LANE_BOT, 0)
+		local vTop = GetLaneFrontLocation(nTeam, LANE_TOP, 0)
+		local vMid = GetLaneFrontLocation(nTeam, LANE_MID, 0)
+		--print(GetUnitToLocationDistance(hHero, vMid))
+		if GetUnitToLocationDistance(hHero, vBot) < 2500 then
+			return LANE_BOT
+		end
+		if GetUnitToLocationDistance(hHero, vTop) < 2500 then
+			return LANE_TOP
+		end
+		if GetUnitToLocationDistance(hHero, vMid) < 2500 then
+			return LANE_MID
+		end
+		return LANE_NONE
 end
 -------------------------------------------------------------------------------------------------------------------------------------
 
@@ -1039,7 +1145,7 @@ function FillLaneAssignmentTable()
 	for i = 1, #TeamMember
 	do
 		if GetTeamMember(i) ~= nil and GetTeamMember(i):IsHero() then
-			local unit_name =  GetTeamMember(i):GetUnitName(); 
+			local unit_name =	GetTeamMember(i):GetUnitName(); 
 			if PairsHeroNameNRole[unit_name] == "support" and not supportAlreadyAssigned then
 				HeroLanes[i] = LANE_TOP;
 				supportAlreadyAssigned = true;
@@ -1069,7 +1175,7 @@ function FillLAHumanCaptain()
 	for i = 1, #TeamMember
 	do
 		if GetTeamMember(i) ~= nil and GetTeamMember(i):IsHero() then
-			local unit_name =  GetTeamMember(i):GetUnitName(); 
+			local unit_name =	GetTeamMember(i):GetUnitName(); 
 			local key = GetFromHumanPick(unit_name);
 			if key ~= nil then
 				if key == 1 then
@@ -1120,12 +1226,12 @@ end
 ---------------------------------------------------------MID ONLY LANE ASSIGNMENT------------------------------------------------------
 function MOLaneAssignment()
 	local lanes = {
-        [1] = LANE_MID,
-        [2] = LANE_MID,
-        [3] = LANE_MID,
-        [4] = LANE_MID,
-        [5] = LANE_MID,
-        };
+		[1] = LANE_MID,
+		[2] = LANE_MID,
+		[3] = LANE_MID,
+		[4] = LANE_MID,
+		[5] = LANE_MID,
+		};
 	return lanes;	
 end
 ---------------------------------------------------------------------------------------------------------------------------------------
@@ -1133,12 +1239,12 @@ end
 ---------------------------------------------------------1 VS 1 LANE ASSIGNMENT------------------------------------------------------
 function OneVsOneLaneAssignment()
 	local lanes = {
-        [1] = LANE_MID,
-        [2] = LANE_TOP,
-        [3] = LANE_TOP,
-        [4] = LANE_TOP,
-        [5] = LANE_TOP,
-        };
+		[1] = LANE_MID,
+		[2] = LANE_TOP,
+		[3] = LANE_TOP,
+		[4] = LANE_TOP,
+		[5] = LANE_TOP,
+		};
 	return lanes;	
 end
 ---------------------------------------------------------------------------------------------------------------------------------------

--- a/item_purchase_generic.lua
+++ b/item_purchase_generic.lua
@@ -121,11 +121,11 @@ for i=1, math.ceil(#bot.itemToBuy/2) do
 end
 
 --Temporary change phase boots to power thread due to behavior change
-for i=1, #bot.itemToBuy do
-	if bot.itemToBuy[i] == 'item_phase_boots' then
-		bot.itemToBuy[i] = 'item_power_treads_str';
-	end	
-end	
+-- for i=1, #bot.itemToBuy do
+	-- if bot.itemToBuy[i] == 'item_phase_boots' then
+		-- bot.itemToBuy[i] = 'item_power_treads_str';
+	-- end	
+-- end	
 --------------------------------------------------------------------------
 
 --[[print(bot:GetUnitName())

--- a/mode_ward_generic.lua
+++ b/mode_ward_generic.lua
@@ -11,8 +11,15 @@ local wt = nil;
 local itemWard = nil;
 local targetLoc = nil;
 local smoke = nil;
-local wardCastTime = -90;
-local swapTime = -90;
+local itemSwapCooldown = 7.0;
+local gameStartTime = -90;
+local wardCastTime = gameStartTime;
+local swapTimeDefault = gameStartTime;
+local swapTime = gameStartTime;
+
+local isWardSwaped = function()
+    return swapTime > gameStartTime;
+end
 
 bot.ward = false;
 bot.steal = false;
@@ -166,9 +173,11 @@ function Think()
 	
 	if bot.ward then
 		if targetDist <= nWardCastRange then
-			if  DotaTime() > swapTime + 7.0 then
+			if DotaTime() > swapTime + itemSwapCooldown then
 				bot:Action_UseAbilityOnLocation(itemWard, targetLoc);
-				wardCastTime = DotaTime();	
+				if isWardSwaped() then
+					wardCastTime = DotaTime();
+				end
 				return
 			else
 				if targetLoc.x == Vector(-2948.000000, 769.000000, 0.000000) then

--- a/util.lua
+++ b/util.lua
@@ -643,6 +643,40 @@ function utilsModule.GetLocationDanger( vLoc )
 
     return danger
 end
+
+function utilsModule.IsDangerDistFromEnemyMidTower()
+  local npcBot = GetBot()
+  local tower = nil
+    
+  if GetTeam() == TEAM_DIRE then
+      tower = GetTower(TEAM_RADIANT, TOWER_MID_1)
+  else
+      tower = GetTower(TEAM_DIRE, TOWER_MID_1)
+  end
+  
+   if tower and #(npcBot:GetLocation() - tower:GetLocation()) < 1000 then
+      return true
+   end
+   
+   return false
+end
+
+function utilsModule.GetDistFromEnemyMidTower()
+  local npcBot = GetBot()
+  local tower =  nil
+    
+  if GetTeam() == TEAM_DIRE then
+      tower = GetTower(TEAM_RADIANT, TOWER_MID_1)
+  else
+      tower = GetTower(TEAM_DIRE, TOWER_MID_1)
+  end
+  
+  if tower then
+      return #(npcBot:GetLocation() - tower:GetLocation())
+  end
+ 
+  return 30000
+end
 ----------------------------------------------------------------------------------------------------
 
 return utilsModule


### PR DESCRIPTION
In some cases, especially on medium difficulty, bots hang on warding spot for indefinite time. This fix checks if the ward item was actually swapped with any other item before changing ward casting time.